### PR TITLE
Removes harmful tsconfig settings

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,2 +1,1 @@
 dist
-test

--- a/.eslintignore
+++ b/.eslintignore
@@ -1,1 +1,2 @@
-build
+dist
+test

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -17,6 +17,7 @@ module.exports = {
     'plugin:prettier/recommended', // Enables eslint-plugin-prettier and eslint-config-prettier. This will display prettier errors as ESLint errors. Make sure this is always the last configuration in the extends array.
   ],
   rules: {
+    'prettier/prettier': ['error', { endOfLine: 'auto' }],
     '@typescript-eslint/explicit-function-return-type': 'off',
     '@typescript-eslint/explicit-member-accessibility': 'off',
     '@typescript-eslint/no-explicit-any': 'off',

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -3,7 +3,7 @@ module.exports = {
   parserOptions: {
     ecmaVersion: 2020, // Allows for the parsing of modern ECMAScript features
     sourceType: 'module', // Allows for the use of imports
-    project: './tsconfig.json',
+    project: './tsconfig.eslint.json',
   },
   settings: {
     react: {

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,11 +4,12 @@ on: [push, pull_request]
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.os }}
 
     strategy:
       matrix:
         node-version: [12.x, 14.x]
+        os: [ubuntu-latest, windows-latest, macOS-latest]
 
     steps:
       - uses: actions/checkout@v1

--- a/package-lock.json
+++ b/package-lock.json
@@ -577,15 +577,6 @@
             "ansi-styles": "^4.1.0",
             "supports-color": "^7.1.0"
           }
-        },
-        "rimraf": {
-          "version": "3.0.2",
-          "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
-          "integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
-          "dev": true,
-          "requires": {
-            "glob": "^7.1.3"
-          }
         }
       }
     },
@@ -1146,9 +1137,9 @@
       "dev": true
     },
     "@types/node": {
-      "version": "14.6.4",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-14.6.4.tgz",
-      "integrity": "sha512-Wk7nG1JSaMfMpoMJDKUsWYugliB2Vy55pdjLpmLixeyMi7HizW2I/9QoxsPCkXl3dO+ZOVqPumKaDUv5zJu2uQ==",
+      "version": "14.10.1",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-14.10.1.tgz",
+      "integrity": "sha512-aYNbO+FZ/3KGeQCEkNhHFRIzBOUgc7QvcVNKXbfnhDkSfwUv91JsQQa10rDgKSTSLkXZ1UIyPe4FJJNVgw1xWQ==",
       "dev": true
     },
     "@types/normalize-package-data": {
@@ -1167,9 +1158,9 @@
       }
     },
     "@types/prettier": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/@types/prettier/-/prettier-2.1.0.tgz",
-      "integrity": "sha512-hiYA88aHiEIgDmeKlsyVsuQdcFn3Z2VuFd/Xm/HCnGnPD8UFU5BM128uzzRVVGEzKDKYUrRsRH9S2o+NUy/3IA==",
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@types/prettier/-/prettier-2.1.1.tgz",
+      "integrity": "sha512-2zs+O+UkDsJ1Vcp667pd3f8xearMdopz/z54i99wtRDI5KLmngk7vlrYZD0ZjKHaROR03EznlBbVY9PfAEyJIQ==",
       "dev": true
     },
     "@types/qs": {
@@ -1305,9 +1296,9 @@
       }
     },
     "abab": {
-      "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/abab/-/abab-2.0.4.tgz",
-      "integrity": "sha512-Eu9ELJWCz/c1e9gTiCY+FceWxcqzjYEbqMgtndnuSqZSUCOL73TWNK2mHfIj4Cw2E/ongOp+JISVNCmovt2KYQ==",
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/abab/-/abab-2.0.5.tgz",
+      "integrity": "sha512-9IK9EadsbHo6jLWIpxpR6pL0sazTXV6+SQv25ZB+F7Bj9mJNaOc4nCRabwd5M/JwmUa8idz6Eci6eKfJryPs6Q==",
       "dev": true
     },
     "abstract-logging": {
@@ -1345,9 +1336,9 @@
       "dev": true
     },
     "ajv": {
-      "version": "6.12.4",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.4.tgz",
-      "integrity": "sha512-eienB2c9qVQs2KWexhkrdMLVDoIQCz5KSeLxwg9Lzk4DOfBtIK9PQwwufcsn1jjGuf9WZmqPMbGxOzfcuphJCQ==",
+      "version": "6.12.5",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.5.tgz",
+      "integrity": "sha512-lRF8RORchjpKG50/WFf8xmg7sgCLFiYNNnqdKflk63whMQcWR5ngGjiSXkL9bjxy6B2npOK2HSMN49jEBMSkag==",
       "dev": true,
       "requires": {
         "fast-deep-equal": "^3.1.1",
@@ -2305,9 +2296,9 @@
       }
     },
     "eslint": {
-      "version": "7.8.1",
-      "resolved": "https://registry.npmjs.org/eslint/-/eslint-7.8.1.tgz",
-      "integrity": "sha512-/2rX2pfhyUG0y+A123d0ccXtMm7DV7sH1m3lk9nk2DZ2LReq39FXHueR9xZwshE5MdfSf0xunSaMWRqyIA6M1w==",
+      "version": "7.9.0",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-7.9.0.tgz",
+      "integrity": "sha512-V6QyhX21+uXp4T+3nrNfI3hQNBDa/P8ga7LoQOenwrlEFXrEnUEE+ok1dMtaS3b6rmLXhT1TkTIsG75HMLbknA==",
       "dev": true,
       "requires": {
         "@babel/code-frame": "^7.0.0",
@@ -2380,12 +2371,12 @@
       }
     },
     "eslint-scope": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-5.1.0.tgz",
-      "integrity": "sha512-iiGRvtxWqgtx5m8EyQUJihBloE4EnYeGE/bz1wSPwJE6tZuJUtHlhqDM4Xj2ukE8Dyy1+HCZ4hE0fzIVMzb58w==",
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-5.1.1.tgz",
+      "integrity": "sha512-2NxwbF/hZ0KpepYN0cNbo+FN6XoK7GaHlQhgx/hIZl6Va0bF45RQOOwhLIy8lQDbuCiadSLCBnH2CFYquit5bw==",
       "dev": true,
       "requires": {
-        "esrecurse": "^4.1.0",
+        "esrecurse": "^4.3.0",
         "estraverse": "^4.1.1"
       }
     },
@@ -2810,9 +2801,9 @@
       "dev": true
     },
     "fastify": {
-      "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/fastify/-/fastify-3.3.0.tgz",
-      "integrity": "sha512-dAlGT7MoekQ2w5nmoxq1zFL+vFPcgRNBtMaopQIITLeUwesvfso4bX0bXwYO3vPFLoKgGc/p8GwSDyq6t5O3nA==",
+      "version": "3.4.1",
+      "resolved": "https://registry.npmjs.org/fastify/-/fastify-3.4.1.tgz",
+      "integrity": "sha512-a3I9hjet4XfWFSNYOEO209lERiMNIjpNm7gSuEzESeKAuX5BChJV9r09zWXEJqOLseBUTVCvakjookG7O8Zapw==",
       "dev": true,
       "requires": {
         "abstract-logging": "^2.0.0",
@@ -2823,7 +2814,7 @@
         "fastify-warning": "^0.2.0",
         "find-my-way": "^3.0.0",
         "flatstr": "^1.0.12",
-        "light-my-request": "^4.0.0",
+        "light-my-request": "^4.0.2",
         "pino": "^6.2.1",
         "proxy-addr": "^2.0.5",
         "readable-stream": "^3.4.0",
@@ -2867,9 +2858,9 @@
       }
     },
     "fastify-plugin": {
-      "version": "2.3.3",
-      "resolved": "https://registry.npmjs.org/fastify-plugin/-/fastify-plugin-2.3.3.tgz",
-      "integrity": "sha512-KjVwrTlbOGBLhF80tAYQ8qXQKvc1G7ETlFZbU4n19V1Xoo9BRNQgicv36y9AvPDcIn1hpeHDOdpPkMW02NOVIQ==",
+      "version": "2.3.4",
+      "resolved": "https://registry.npmjs.org/fastify-plugin/-/fastify-plugin-2.3.4.tgz",
+      "integrity": "sha512-I+Oaj6p9oiRozbam30sh39BiuiqBda7yK2nmSPVwDCfIBlKnT8YB3MY+pRQc2Fcd07bf6KPGklHJaQ2Qu81TYQ==",
       "requires": {
         "semver": "^7.3.2"
       }
@@ -3119,9 +3110,9 @@
       }
     },
     "got": {
-      "version": "11.6.1",
-      "resolved": "https://registry.npmjs.org/got/-/got-11.6.1.tgz",
-      "integrity": "sha512-6izGvOsrd/4CsIdQMgweFOTCtS4sAwJTuCzIuVoTbCDzt3+wa3eGIHhSIMgEF6gfCDenslGlMUmAdPap5DkirQ==",
+      "version": "11.6.2",
+      "resolved": "https://registry.npmjs.org/got/-/got-11.6.2.tgz",
+      "integrity": "sha512-/21qgUePCeus29Jk7MEti8cgQUNXFSWfIevNIk4H7u1wmXNDrGPKPY6YsPY+o9CIT/a2DjCjRz0x1nM9FtS2/A==",
       "dev": true,
       "requires": {
         "@sindresorhus/is": "^3.1.1",
@@ -5646,9 +5637,9 @@
       "dev": true
     },
     "pino": {
-      "version": "6.6.0",
-      "resolved": "https://registry.npmjs.org/pino/-/pino-6.6.0.tgz",
-      "integrity": "sha512-rLfJXX8i2P1VNXZY05fDMI/qK1IQSpKnOg5iNY5TRJn+vKhc9hBg1iCiAuOw3hKEAf54MZMlT8P6T+wgYQYpIA==",
+      "version": "6.6.1",
+      "resolved": "https://registry.npmjs.org/pino/-/pino-6.6.1.tgz",
+      "integrity": "sha512-DOgm7rn6ctBkBYemHXSLj7+j3o3U1q1FWBXbHcprur8mA93QcJSycEkEqhqKiFB9Mx/3Qld2FGr6+9yfQza0kA==",
       "dev": true,
       "requires": {
         "fast-redact": "^2.0.0",

--- a/package.json
+++ b/package.json
@@ -6,8 +6,8 @@
   "types": "dist/index.d.ts",
   "scripts": {
     "build": "rimraf ./dist && mkdir dist && tsc --outDir dist && git rev-parse HEAD > BUILD_SHA",
-    "lint": "eslint '*/**/*.{js,ts,tsx}'",
-    "lint:fix": "prettier --loglevel warn --write \"src/**/*.{ts,tsx}\" && eslint '*/**/*.{js,ts,tsx}' --quiet --fix",
+    "lint": "eslint \"*/**/*.{js,ts,tsx}\"",
+    "lint:fix": "prettier --loglevel warn --write \"src/**/*.{ts,tsx}\" && eslint \"*/**/*.{js,ts,tsx}\" --quiet --fix",
     "prepublishOnly": "npm run build",
     "test": "npm run build && npm run test:unit && npm run lint",
     "test:unit": "jest"

--- a/src/AuthenticationRoute.ts
+++ b/src/AuthenticationRoute.ts
@@ -1,5 +1,5 @@
 /// <reference types="fastify-secure-session" />
-import http from 'http'
+import * as http from 'http'
 import AuthenticationError from './errors'
 import Authenticator from './Authenticator'
 import { Strategy } from './strategies'

--- a/src/CreateInitializePlugin.ts
+++ b/src/CreateInitializePlugin.ts
@@ -1,7 +1,7 @@
 import fp from 'fastify-plugin'
 import { logIn, logOut, isAuthenticated, isUnauthenticated } from './decorators'
 import Authenticator from './Authenticator'
-import flash from 'fastify-flash'
+import flash = require('fastify-flash')
 
 export function CreateInitializePlugin(passport: Authenticator, options: { userProperty?: string } = {}) {
   return fp(async (fastify) => {

--- a/test/helpers.ts
+++ b/test/helpers.ts
@@ -1,10 +1,10 @@
-import fs from 'fs'
+import * as fs from 'fs'
 import fastify, { FastifyInstance } from 'fastify'
 import fastifySecureSession from 'fastify-secure-session'
 import Authenticator from '../src/Authenticator'
 import { Strategy } from '../src/strategies'
 import { InjectOptions, Response as LightMyRequestResponse } from 'light-my-request'
-import parseCookies from 'set-cookie-parser'
+import * as parseCookies from 'set-cookie-parser'
 
 const SecretKey = fs.readFileSync(__dirname + '/secure.key')
 

--- a/tsconfig.eslint.json
+++ b/tsconfig.eslint.json
@@ -1,0 +1,7 @@
+{
+  "extends": "./tsconfig.json",
+  "include": [
+    "src",
+    "test"
+  ]
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -6,20 +6,16 @@
     "module": "commonjs",
     "pretty": true,
     "noEmitOnError": true,
-    "experimentalDecorators": true,
-    "sourceMap": true,
-    "emitDecoratorMetadata": true,
     "strict": true,
     "noImplicitAny": false,
-    "esModuleInterop": true,
     "removeComments": true,
     "noUnusedLocals": true,
-    "lib": ["esnext"],
+    "lib": [
+      "esnext"
+    ],
     "rootDir": "./src"
   },
-  "formatCodeOptions": {
-    "identSize": 2,
-    "tabSize": 2
-  },
-  "include": ["src"]
+  "include": [
+    "src"
+  ]
 }


### PR DESCRIPTION
- Fixes eslint path issues (closes https://github.com/fastify/fastify-passport/issues/5)
- Updates fastify-plugin in the package-lock.json to fix export default issue (ref: https://github.com/fastify/fastify-plugin/pull/106)
- Uses `import flash = require('fastify-flash')` to make it work with both esModuleInterop settings (ref: https://github.com/fastify/fastify-helmet/pull/96)

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
