### PR TITLE
Fix FSTDEP006 by exposing the Authenticator object using a getter decorator

### DIFF
--- a/src/CreateInitializePlugin.ts
+++ b/src/CreateInitializePlugin.ts
@@ -6,7 +6,11 @@ import flash = require('fastify-flash')
 export function CreateInitializePlugin(passport: Authenticator, options: { userProperty?: string } = {}) {
   return fp(async (fastify) => {
     void fastify.register(flash)
-    fastify.decorateRequest('passport', passport)
+    fastify.decorateRequest('passport', {
+      getter() {
+        return passport
+      },
+    })
     fastify.decorateRequest('logIn', logIn)
     fastify.decorateRequest('login', logIn)
     fastify.decorateRequest('logOut', logOut)


### PR DESCRIPTION
We're decorating the request with the Authenticator object responsible for managing passport authentication mostly so that request handlers installed by the Authenticator can ensure they're operating in an encapsulation context where the rest of the fastify-passport plugin was initialized correctly. Fastify has deprecated reference decorators to avoid accidental data-sharing between requests or memory leaks. In this case, I think we actually *want* to share this piece of data (the Authenticator instance) between requests, so we use the escape hatch to avoid the deprecation warning by using a getter decorator to return it.

An alternative might be to set a scalar sigil of some sort on the request, but I feel like that's less clear, or to use an onRequest hook, which is slower just to avoid the deprecation warning, which I think is silly. So, a getter it is!

#### Checklist

- [X] run `npm run test` and `npm run benchmark`
- [X] tests and/or benchmarks are included
- [X] documentation is changed or added
- [X] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)

@mcollina sorry for adding more to your plate, who should I tag for reviews for this kind of stuff? 
