### PR TITLE
Implement and document handled deserialization failures

### DIFF
--- a/src/Authenticator.ts
+++ b/src/Authenticator.ts
@@ -264,11 +264,13 @@ export class Authenticator {
     this.deserializers.push(fn)
   }
 
-  async deserializeUser<StoredUser>(stored: StoredUser, request: FastifyRequest) {
+  async deserializeUser<StoredUser>(stored: StoredUser, request: FastifyRequest): Promise<StoredUser | false> {
     const result = await this.runStack(this.deserializers, stored, request)
 
     if (result) {
       return result
+    } else if (result === null || result === false) {
+      return false
     } else {
       throw new Error(`Failed to deserialize user out of session. Tried ${this.deserializers.length} serializers.`)
     }

--- a/test/helpers.ts
+++ b/test/helpers.ts
@@ -24,6 +24,28 @@ export class TestStrategy extends Strategy {
   }
 }
 
+export class TestDatabaseStrategy extends Strategy {
+  constructor(name: string, readonly database: Record<string, { id: string; login: string; password: string }> = {}) {
+    super(name)
+  }
+
+  authenticate(request: any, _options?: { pauseStream?: boolean }) {
+    if (request.isAuthenticated()) {
+      return this.pass()
+    }
+    if (request.body) {
+      const user = Object.values(this.database).find(
+        (user) => user.login == request.body.login && user.password == request.body.password
+      )
+      if (user) {
+        return this.success(user)
+      }
+    }
+
+    this.fail()
+  }
+}
+
 /** Class representing a browser in tests */
 export class TestBrowserSession {
   cookies: Record<string, string>

--- a/test/session-serialization.test.ts
+++ b/test/session-serialization.test.ts
@@ -1,4 +1,7 @@
+/* eslint-disable @typescript-eslint/no-empty-function */
+import { FastifyInstance } from 'fastify'
 import Authenticator from '../src/Authenticator'
+import { getTestServer, TestDatabaseStrategy, TestStrategy } from './helpers'
 
 describe('Authenticator session serialization', () => {
   test('it should roundtrip a user', async () => {
@@ -12,5 +15,171 @@ describe('Authenticator session serialization', () => {
     expect(await fastifyPassport.deserializeUser(await fastifyPassport.serializeUser(user, request), request)).toEqual(
       user
     )
+  })
+
+  const setupSerializationTestServer = async (fastifyPassport: Authenticator) => {
+    const server = getTestServer()
+    void server.register(fastifyPassport.initialize())
+    void server.register(fastifyPassport.secureSession())
+    server.get(
+      '/',
+      { preValidation: fastifyPassport.authenticate('test', { authInfo: false }) },
+      async () => 'hello world!'
+    )
+    server.post(
+      '/login',
+      { preValidation: fastifyPassport.authenticate('test', { successRedirect: '/', authInfo: false }) },
+      () => {}
+    )
+    server.get('/unprotected', async () => 'some content')
+    return server
+  }
+
+  const verifySuccessfulLogin = async (server: FastifyInstance) => {
+    const loginResponse = await server.inject({
+      method: 'POST',
+      url: '/login',
+      payload: { login: 'test', password: 'test' },
+    })
+
+    expect(loginResponse.statusCode).toEqual(302)
+    expect(loginResponse.headers.location).toEqual('/')
+
+    const homeResponse = await server.inject({
+      url: '/',
+      headers: {
+        cookie: loginResponse.headers['set-cookie'],
+      },
+      method: 'GET',
+    })
+
+    expect(homeResponse.body).toEqual('hello world!')
+    expect(homeResponse.statusCode).toEqual(200)
+  }
+
+  test('should allow multiple user serializers and deserializers', async () => {
+    const fastifyPassport = new Authenticator()
+    fastifyPassport.use('test', new TestStrategy('test'))
+    fastifyPassport.registerUserSerializer(async () => {
+      throw 'pass'
+    })
+    fastifyPassport.registerUserSerializer(async () => {
+      throw 'pass'
+    })
+    fastifyPassport.registerUserSerializer(async (user) => {
+      return JSON.stringify(user)
+    })
+    fastifyPassport.registerUserDeserializer(async () => {
+      throw 'pass'
+    })
+    fastifyPassport.registerUserDeserializer(async () => {
+      throw 'pass'
+    })
+    fastifyPassport.registerUserDeserializer(async (serialized: string) => JSON.parse(serialized))
+    const server = await setupSerializationTestServer(fastifyPassport)
+    await verifySuccessfulLogin(server)
+  })
+
+  test('should allow user serializers/deserializers that work like a database', async () => {
+    const fastifyPassport = new Authenticator()
+    const strategy = new TestDatabaseStrategy('test', { '1': { id: '1', login: 'test', password: 'test' } })
+    fastifyPassport.use('test', strategy)
+    fastifyPassport.registerUserSerializer<{ id: string; name: string }, string>(async (user) => user.id)
+    fastifyPassport.registerUserDeserializer(async (serialized: string) => strategy.database[serialized])
+
+    const server = await setupSerializationTestServer(fastifyPassport)
+    await verifySuccessfulLogin(server)
+    await verifySuccessfulLogin(server)
+  })
+
+  test('should throw if user deserializers return undefined', async () => {
+    jest.spyOn(console, 'error').mockImplementation(jest.fn())
+    const fastifyPassport = new Authenticator()
+    const strategy = new TestDatabaseStrategy('test', { '1': { id: '1', login: 'test', password: 'test' } })
+    fastifyPassport.use('test', strategy)
+    fastifyPassport.registerUserSerializer<{ id: string; name: string }, string>(async (user) => user.id)
+    fastifyPassport.registerUserDeserializer(async (serialized: string) => strategy.database[serialized])
+
+    const server = await setupSerializationTestServer(fastifyPassport)
+    await verifySuccessfulLogin(server)
+
+    const loginResponse = await server.inject({
+      method: 'POST',
+      url: '/login',
+      payload: { login: 'test', password: 'test' },
+    })
+
+    expect(loginResponse.statusCode).toEqual(302)
+    expect(loginResponse.headers.location).toEqual('/')
+
+    // user id 1 is logged in now, simulate deleting them from the database while logged in
+    delete strategy.database['1']
+
+    const homeResponse = await server.inject({
+      url: '/',
+      headers: {
+        cookie: loginResponse.headers['set-cookie'],
+      },
+      method: 'GET',
+    })
+
+    expect(homeResponse.statusCode).toEqual(500)
+    expect(homeResponse.body).toContain('Failed to deserialize user out of session')
+
+    // can't serve other requests either because the secure session decode fails, which would populate request.user even for unauthenticated requests
+    const otherResponse = await server.inject({
+      url: '/unprotected',
+      headers: {
+        cookie: loginResponse.headers['set-cookie'],
+      },
+      method: 'GET',
+    })
+
+    expect(otherResponse.statusCode).toEqual(500)
+  })
+
+  test('should deny access if user deserializers return null for logged in sessions', async () => {
+    const fastifyPassport = new Authenticator()
+    const strategy = new TestDatabaseStrategy('test', { '1': { id: '1', login: 'test', password: 'test' } })
+    fastifyPassport.use('test', strategy)
+    fastifyPassport.registerUserSerializer<{ id: string; name: string }, string>(async (user) => user.id)
+    fastifyPassport.registerUserDeserializer(async (serialized: string) => strategy.database[serialized] || null)
+
+    const server = await setupSerializationTestServer(fastifyPassport)
+    await verifySuccessfulLogin(server)
+
+    const loginResponse = await server.inject({
+      method: 'POST',
+      url: '/login',
+      payload: { login: 'test', password: 'test' },
+    })
+
+    expect(loginResponse.statusCode).toEqual(302)
+    expect(loginResponse.headers.location).toEqual('/')
+
+    // user id 1 is logged in now, simulate deleting them from the database while logged in
+    delete strategy.database['1']
+
+    const homeResponse = await server.inject({
+      url: '/',
+      headers: {
+        cookie: loginResponse.headers['set-cookie'],
+      },
+      method: 'GET',
+    })
+
+    expect(homeResponse.statusCode).toEqual(401)
+
+    // should still be able to serve unauthenticated requests just fine
+    const otherResponse = await server.inject({
+      url: '/unprotected',
+      headers: {
+        cookie: loginResponse.headers['set-cookie'],
+      },
+      method: 'GET',
+    })
+
+    expect(otherResponse.statusCode).toEqual(200)
+    expect(otherResponse.body).toEqual('some content')
   })
 })


### PR DESCRIPTION
I missed this nuance during the original porting -- returning false or null from a user deserializer means something special. It means the user not being found is not an error condition but just means the session has out-of-date data, and should be logged out. See https://github.com/jaredhanson/passport/issues/6 for the original context on how this is a thing in passport. This recreates that functionality and tests it!

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [X] tests and/or benchmarks are included
- [X] documentation is changed or added
- [X] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
