### PR TITLE
fix: fastifyPassport is undefined when use native ESM import

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -943,6 +943,12 @@
         "@types/node": "*"
       }
     },
+    "@types/semver": {
+      "version": "7.3.4",
+      "resolved": "https://registry.npmjs.org/@types/semver/-/semver-7.3.4.tgz",
+      "integrity": "sha512-+nVsLKlcUCeMzD2ufHEYuJ9a2ovstb6Dp52A5VsoKxDXgvE051XgHI/33I1EymwkRGQkwnA0LkhnUzituGs4EQ==",
+      "dev": true
+    },
     "@types/serve-static": {
       "version": "1.13.8",
       "resolved": "https://registry.npmjs.org/@types/serve-static/-/serve-static-1.13.8.tgz",
@@ -1023,48 +1029,6 @@
         "@typescript-eslint/types": "4.14.1",
         "@typescript-eslint/typescript-estree": "4.14.1",
         "debug": "^4.1.1"
-      }
-    },
-    "@typescript-eslint/scope-manager": {
-      "version": "4.14.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-4.14.1.tgz",
-      "integrity": "sha512-F4bjJcSqXqHnC9JGUlnqSa3fC2YH5zTtmACS1Hk+WX/nFB0guuynVK5ev35D4XZbdKjulXBAQMyRr216kmxghw==",
-      "dev": true,
-      "requires": {
-        "@typescript-eslint/types": "4.14.1",
-        "@typescript-eslint/visitor-keys": "4.14.1"
-      }
-    },
-    "@typescript-eslint/types": {
-      "version": "4.14.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-4.14.1.tgz",
-      "integrity": "sha512-SkhzHdI/AllAgQSxXM89XwS1Tkic7csPdndUuTKabEwRcEfR8uQ/iPA3Dgio1rqsV3jtqZhY0QQni8rLswJM2w==",
-      "dev": true
-    },
-    "@typescript-eslint/typescript-estree": {
-      "version": "4.14.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-4.14.1.tgz",
-      "integrity": "sha512-M8+7MbzKC1PvJIA8kR2sSBnex8bsR5auatLCnVlNTJczmJgqRn8M+sAlQfkEq7M4IY3WmaNJ+LJjPVRrREVSHQ==",
-      "dev": true,
-      "requires": {
-        "@typescript-eslint/types": "4.14.1",
-        "@typescript-eslint/visitor-keys": "4.14.1",
-        "debug": "^4.1.1",
-        "globby": "^11.0.1",
-        "is-glob": "^4.0.1",
-        "lodash": "^4.17.15",
-        "semver": "^7.3.2",
-        "tsutils": "^3.17.1"
-      }
-    },
-    "@typescript-eslint/visitor-keys": {
-      "version": "4.14.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-4.14.1.tgz",
-      "integrity": "sha512-TAblbDXOI7bd0C/9PE1G+AFo7R5uc+ty1ArDoxmrC1ah61Hn6shURKy7gLdRb1qKJmjHkqu5Oq+e4Kt0jwf1IA==",
-      "dev": true,
-      "requires": {
-        "@typescript-eslint/types": "4.14.1",
-        "eslint-visitor-keys": "^2.0.0"
       }
     },
     "@typescript-eslint/scope-manager": {

--- a/package.json
+++ b/package.json
@@ -51,6 +51,7 @@
     "@types/jest": "^26.0.19",
     "@types/node": "^14.14.17",
     "@types/passport": "^1.0.5",
+    "@types/semver": "^7.3.4",
     "@types/set-cookie-parser": "^2.4.0",
     "@typescript-eslint/eslint-plugin": "^4.11.1",
     "@typescript-eslint/parser": "^4.11.1",
@@ -65,6 +66,7 @@
     "passport-google-oauth": "^2.0.0",
     "prettier": "^2.0.5",
     "rimraf": "^3.0.2",
+    "semver": "^7.3.4",
     "set-cookie-parser": "^2.4.6",
     "ts-jest": "^26.3.0",
     "typescript": "^4.1.3"

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,5 +2,7 @@ import Authenticator from './Authenticator'
 import './type-extensions' // necessary to make sure that the fastify types are augmented
 const passport = new Authenticator()
 
+// Workaround for importing fastify-passport in native ESM context
+module.exports = exports = passport
 export default passport
 export { Strategy } from './strategies'

--- a/test/esm/default-esm-export.mjs
+++ b/test/esm/default-esm-export.mjs
@@ -1,0 +1,3 @@
+import passport from '../../dist/index.js'
+
+passport.initialize()

--- a/test/esm/esm.test.ts
+++ b/test/esm/esm.test.ts
@@ -1,0 +1,20 @@
+import { spawnSync } from 'child_process'
+import * as semver from 'semver'
+import { join } from 'path'
+
+describe('Native ESM import', () => {
+  const defaultExportTest = semver.lt(process.versions.node, '13.3.0') ? it.skip : it
+  const namedExportTest = semver.lt(process.versions.node, '14.13.0') ? it.skip : it
+
+  defaultExportTest('should be able to use default export', () => {
+    const { status } = spawnSync('node', [join(__dirname, 'default-esm-export.mjs')])
+
+    expect(status).toBe(0)
+  })
+
+  namedExportTest('should be able to use named export', () => {
+    const { status } = spawnSync('node', [join(__dirname, 'named-esm-export.mjs')])
+
+    expect(status).toBe(0)
+  })
+})

--- a/test/esm/named-esm-export.mjs
+++ b/test/esm/named-esm-export.mjs
@@ -1,0 +1,3 @@
+import { Strategy } from '../../dist/index.js'
+
+class MS extends Strategy {}


### PR DESCRIPTION
Fixes #82 

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
