### PR TITLE
chore(npm): switch fastify-secure-session to a dev dep

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1147,48 +1147,6 @@
         }
       }
     },
-    "@typescript-eslint/scope-manager": {
-      "version": "4.14.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-4.14.1.tgz",
-      "integrity": "sha512-F4bjJcSqXqHnC9JGUlnqSa3fC2YH5zTtmACS1Hk+WX/nFB0guuynVK5ev35D4XZbdKjulXBAQMyRr216kmxghw==",
-      "dev": true,
-      "requires": {
-        "@typescript-eslint/types": "4.14.1",
-        "@typescript-eslint/visitor-keys": "4.14.1"
-      }
-    },
-    "@typescript-eslint/types": {
-      "version": "4.14.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-4.14.1.tgz",
-      "integrity": "sha512-SkhzHdI/AllAgQSxXM89XwS1Tkic7csPdndUuTKabEwRcEfR8uQ/iPA3Dgio1rqsV3jtqZhY0QQni8rLswJM2w==",
-      "dev": true
-    },
-    "@typescript-eslint/typescript-estree": {
-      "version": "4.14.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-4.14.1.tgz",
-      "integrity": "sha512-M8+7MbzKC1PvJIA8kR2sSBnex8bsR5auatLCnVlNTJczmJgqRn8M+sAlQfkEq7M4IY3WmaNJ+LJjPVRrREVSHQ==",
-      "dev": true,
-      "requires": {
-        "@typescript-eslint/types": "4.14.1",
-        "@typescript-eslint/visitor-keys": "4.14.1",
-        "debug": "^4.1.1",
-        "globby": "^11.0.1",
-        "is-glob": "^4.0.1",
-        "lodash": "^4.17.15",
-        "semver": "^7.3.2",
-        "tsutils": "^3.17.1"
-      }
-    },
-    "@typescript-eslint/visitor-keys": {
-      "version": "4.14.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-4.14.1.tgz",
-      "integrity": "sha512-TAblbDXOI7bd0C/9PE1G+AFo7R5uc+ty1ArDoxmrC1ah61Hn6shURKy7gLdRb1qKJmjHkqu5Oq+e4Kt0jwf1IA==",
-      "dev": true,
-      "requires": {
-        "@typescript-eslint/types": "4.14.1",
-        "eslint-visitor-keys": "^2.0.0"
-      }
-    },
     "abab": {
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/abab/-/abab-2.0.5.tgz",
@@ -1813,12 +1771,14 @@
     "cookie": {
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.4.1.tgz",
-      "integrity": "sha512-ZwrFkGJxUR3EIoXtO+yVE69Eb7KlixbaeAWfBQB9vVsNn/o+Yw69gBWSSDK825hQNdN+wF8zELf3dFNl/kxkUA=="
+      "integrity": "sha512-ZwrFkGJxUR3EIoXtO+yVE69Eb7KlixbaeAWfBQB9vVsNn/o+Yw69gBWSSDK825hQNdN+wF8zELf3dFNl/kxkUA==",
+      "dev": true
     },
     "cookie-signature": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.1.0.tgz",
-      "integrity": "sha512-Alvs19Vgq07eunykd3Xy2jF0/qSNv2u7KDbAek9H5liV1UMijbqFs5cycZvv5dVsvseT/U4H8/7/w8Koh35C4A=="
+      "integrity": "sha512-Alvs19Vgq07eunykd3Xy2jF0/qSNv2u7KDbAek9H5liV1UMijbqFs5cycZvv5dVsvseT/U4H8/7/w8Koh35C4A==",
+      "dev": true
     },
     "copy-descriptor": {
       "version": "0.1.1",
@@ -2667,6 +2627,7 @@
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/fastify-cookie/-/fastify-cookie-4.2.0.tgz",
       "integrity": "sha512-BZjgIA143YevEjAwJmqfnJJ5hIonkl49nLBjRLbErFKor/Rd8DZ0xnHnmxSk8xUhnr5g5vxKHnH3/dQt+11cpg==",
+      "dev": true,
       "requires": {
         "cookie": "^0.4.0",
         "cookie-signature": "^1.1.0",
@@ -2706,6 +2667,7 @@
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/fastify-secure-session/-/fastify-secure-session-2.3.0.tgz",
       "integrity": "sha512-qJe2+tU7tbUxp4toec22vrxW9WTa6jdu62+5GROA6z2nc1uncYJBHnzwFtH/oiO1tYsW+9Ec8xfn4DJkG74myQ==",
+      "dev": true,
       "requires": {
         "fastify-cookie": "^4.0.2",
         "fastify-plugin": "^2.0.0",
@@ -2716,6 +2678,7 @@
           "version": "2.3.4",
           "resolved": "https://registry.npmjs.org/fastify-plugin/-/fastify-plugin-2.3.4.tgz",
           "integrity": "sha512-I+Oaj6p9oiRozbam30sh39BiuiqBda7yK2nmSPVwDCfIBlKnT8YB3MY+pRQc2Fcd07bf6KPGklHJaQ2Qu81TYQ==",
+          "dev": true,
           "requires": {
             "semver": "^7.3.2"
           }
@@ -3187,7 +3150,8 @@
     "ini": {
       "version": "1.3.8",
       "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.8.tgz",
-      "integrity": "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew=="
+      "integrity": "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==",
+      "dev": true
     },
     "ip-regex": {
       "version": "2.1.0",
@@ -4318,7 +4282,8 @@
     "node-gyp-build": {
       "version": "4.2.3",
       "resolved": "https://registry.npmjs.org/node-gyp-build/-/node-gyp-build-4.2.3.tgz",
-      "integrity": "sha512-MN6ZpzmfNCRM+3t57PTJHgHyw/h4OWnZ6mR8P5j/uZtqQr46RRuDE/P+g3n0YR/AiYXeWixZZzaip77gdICfRg=="
+      "integrity": "sha512-MN6ZpzmfNCRM+3t57PTJHgHyw/h4OWnZ6mR8P5j/uZtqQr46RRuDE/P+g3n0YR/AiYXeWixZZzaip77gdICfRg==",
+      "dev": true
     },
     "node-int64": {
       "version": "0.4.0",
@@ -5534,6 +5499,7 @@
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/sodium-native/-/sodium-native-3.2.0.tgz",
       "integrity": "sha512-8aq/vQSegLwsRch8Sb/Bpf9aAqlNe5dp0+NVhb9UjHv42zDZ0D5zX3wBRUbXK9Ejum9uZE6DUgT4vVLlUFRBWg==",
+      "dev": true,
       "requires": {
         "ini": "^1.3.5",
         "node-gyp-build": "^4.2.0"

--- a/package.json
+++ b/package.json
@@ -41,8 +41,7 @@
   },
   "dependencies": {
     "fastify-flash": "^2.0.2",
-    "fastify-plugin": "^3.0.0",
-    "fastify-secure-session": "^2.2.0"
+    "fastify-plugin": "^3.0.0"
   },
   "peerDependencies": {
     "fastify": "^3.0.3"
@@ -55,9 +54,10 @@
     "@types/set-cookie-parser": "^2.4.0",
     "@typescript-eslint/eslint-plugin": "^4.11.1",
     "@typescript-eslint/parser": "^4.11.1",
-    "eslint": "^7.16.0",
     "eslint-config-prettier": "^7.1.0",
     "eslint-plugin-prettier": "^3.3.0",
+    "eslint": "^7.16.0",
+    "fastify-secure-session": "^2.2.0",
     "fastify": "^3.9.2",
     "got": "^11.8.1",
     "jest": "^26.1.0",


### PR DESCRIPTION
Following the discussion in #91, this PR switches `fastify-secure-session` to a dev dep.

Would be great to have a published release soon :)!