### PR TITLE
Multiple disjoint registered instance support

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,31 +18,34 @@ npm install fastify-passport
 ## Example
 
 ```js
-import fastifyPassport from "fastify-passport";
-import fastifySecureSession from "fastify-secure-session";
+import fastifyPassport from 'fastify-passport'
+import fastifySecureSession from 'fastify-secure-session'
 
-const server = fastify();
+const server = fastify()
 // set up secure sessions for fastify-passport to store data in
-server.register(fastifySecureSession, { key: fs.readFileSync(path.join(__dirname, "secret-key")) });
+server.register(fastifySecureSession, { key: fs.readFileSync(path.join(__dirname, 'secret-key')) })
 // initialize fastify-passport and connect it to the secure-session storage. Note: both of these plugins are mandatory.
-server.register(fastifyPassport.initialize());
-server.register(fastifyPassport.secureSession());
+server.register(fastifyPassport.initialize())
+server.register(fastifyPassport.secureSession())
+
+// register an example strategy for fastifyPassport to authenticate users using
+fastifyPassport.use('test', new SomePassportStrategy()) // you'd probably use some passport strategy from npm here
 
 // Add an authentication for a route which will use the strategy named "test" to protect the route
 server.get(
-  "/",
-  { preValidation: fastifyPassport.authenticate("test", { authInfo: false }) },
-  async () => "hello world!"
-);
+  '/',
+  { preValidation: fastifyPassport.authenticate('test', { authInfo: false }) },
+  async () => 'hello world!'
+)
 
 // Add an authentication for a route which will use the strategy named "test" to protect the route, and redirect on success to a particular other route.
 server.post(
-  "/login",
-  { preValidation: fastifyPassport.authenticate("test", { successRedirect: "/", authInfo: false }) },
+  '/login',
+  { preValidation: fastifyPassport.authenticate('test', { successRedirect: '/', authInfo: false }) },
   () => {}
-);
+)
 
-server.listen(0);
+server.listen(0)
 ```
 
 ## Session Serialization
@@ -106,8 +109,8 @@ An optional `status` or `statuses` argument will be passed when authentication f
 
 ```js
 fastify.get(
-  "/",
-  { preValidation: fastifyPassport.authenticate("test", { authInfo: false }) },
+  '/',
+  { preValidation: fastifyPassport.authenticate('test', { authInfo: false }) },
   async (request, reply, err, user, info, status) => {
     if (err !== null) {
       console.warn(err)
@@ -115,7 +118,7 @@ fastify.get(
       console.log(`Hello ${user.name}!`)
     }
   }
-);
+)
 ```
 
 Examples:
@@ -126,6 +129,30 @@ Examples:
 
 Note that if a callback is supplied, it becomes the application's responsibility to log-in the user, establish a session, and otherwise perform the desired operations.
 
+#### Multiple Strategies
+
+`fastify-passport` supports authenticating with a list of strategies, and will try each in order until one passes. Pass an array of strategy names to `authenticate` for this:
+
+```js
+// somewhere before several strategies are registered
+fastifyPassport.use('google', new FancyGoogleStrategy())
+fastifyPassport.use('twitter', new CoolTwitterStrategy())
+fastifyPassport.use('facebook', new FacebookStrategy())
+
+// and then an `authenticate` call can test incoming requests against multiple strategies
+fastify.get(
+  '/',
+  { preValidation: fastifyPassport.authenticate(['google', 'twitter', 'facebook'], { authInfo: false }) },
+  async (request, reply, err, user, info, status) => {
+    if (err !== null) {
+      console.warn(err)
+    } else if (user) {
+      console.log(`Hello ${user.name}!`)
+    }
+  }
+)
+```
+
 ### authorize(name, options)
 
 Returns a hook that will authorize a third-party account using the given `strategy` name, with optional `options`. Intended for use as a `preValidation` hook on any route. `.authorize` has the same API as `.authenticate`, but has one key difference: it doesn't modify the logged in user's details. Instead, if authorization is successful, the result provided by the strategy's verify callback will be assigned to `request.account`. The existing login session and `request.user` will be unaffected.
@@ -135,7 +162,7 @@ This function is particularly useful when connecting third-party accounts to the
 Examples:
 
 ```js
-fastifyPassport.authorize("twitter-authz", { failureRedirect: "/account" });
+fastifyPassport.authorize('twitter-authz', { failureRedirect: '/account' })
 ```
 
 ### use([name], strategy)
@@ -161,7 +188,8 @@ However, in certain situations, applications may need dynamically configure and 
 Example:
 
 ```js
-fastifyPassport.unuse("legacy-api");
+fastifyPassport.unuse('legacy-api')
+```
 
 ### registerUserSerializer(serializer: (user, request) => Promise<SerializedUser>)
 

--- a/src/Authenticator.ts
+++ b/src/Authenticator.ts
@@ -17,9 +17,16 @@ export type DeserializeFunction<SerializedUser = any, User = any> = (
 
 export type InfoTransformerFunction = (info: any) => Promise<any>
 
+export interface AuthenticatorOptions {
+  key?: string
+  userProperty?: string
+}
+
 export class Authenticator {
-  public key = 'passport'
-  public userProperty = 'user'
+  // a Fastify-instance wide unique string identifying this instance of fastify-passport (default: "passport")
+  public key: string
+  // the key on the request at which to store the deserialized user value (default: "user")
+  public userProperty: string
   public sessionManager: SecureSessionManager
 
   private strategies: { [k: string]: AnyStrategy } = {}
@@ -27,7 +34,10 @@ export class Authenticator {
   private deserializers: DeserializeFunction<any, any>[] = []
   private infoTransformers: InfoTransformerFunction[] = []
 
-  constructor() {
+  constructor(options: AuthenticatorOptions = {}) {
+    this.key = options.key || 'passport'
+    this.userProperty = options.userProperty || 'user'
+
     this.use(new SessionStrategy(this.deserializeUser.bind(this)))
     this.sessionManager = new SecureSessionManager({ key: this.key }, this.serializeUser.bind(this))
   }

--- a/src/Authenticator.ts
+++ b/src/Authenticator.ts
@@ -62,8 +62,8 @@ export class Authenticator {
     return this
   }
 
-  public initialize(options?: { userProperty?: string }): FastifyPlugin {
-    return CreateInitializePlugin(this, options)
+  public initialize(): FastifyPlugin {
+    return CreateInitializePlugin(this)
   }
 
   /**

--- a/src/CreateInitializePlugin.ts
+++ b/src/CreateInitializePlugin.ts
@@ -3,7 +3,7 @@ import { logIn, logOut, isAuthenticated, isUnauthenticated } from './decorators'
 import Authenticator from './Authenticator'
 import flash = require('fastify-flash')
 
-export function CreateInitializePlugin(passport: Authenticator, options: { userProperty?: string } = {}) {
+export function CreateInitializePlugin(passport: Authenticator) {
   return fp(async (fastify) => {
     void fastify.register(flash)
     fastify.decorateRequest('passport', {
@@ -17,6 +17,6 @@ export function CreateInitializePlugin(passport: Authenticator, options: { userP
     fastify.decorateRequest('logout', logOut)
     fastify.decorateRequest('isAuthenticated', isAuthenticated)
     fastify.decorateRequest('isUnauthenticated', isUnauthenticated)
-    fastify.decorateRequest(options.userProperty || 'user', null)
+    fastify.decorateRequest(passport.userProperty, null)
   })
 }

--- a/src/decorators/is-authenticated.ts
+++ b/src/decorators/is-authenticated.ts
@@ -1,10 +1,6 @@
 import { FastifyRequest } from 'fastify'
 
 export function isAuthenticated(this: FastifyRequest): boolean {
-  let property = 'user'
-  if (this.passport && this.passport) {
-    property = this.passport.userProperty || 'user'
-  }
-
+  const property = this.passport.userProperty
   return this[property] ? true : false
 }

--- a/src/decorators/login.ts
+++ b/src/decorators/login.ts
@@ -28,7 +28,7 @@ export async function logIn<T = unknown>(this: FastifyRequest, user: T, options:
     throw new Error('passport.initialize() plugin not in use')
   }
 
-  const property = this.passport.userProperty || 'user'
+  const property = this.passport.userProperty
   const session = options.session === undefined ? true : options.session
 
   this[property] = user

--- a/src/decorators/logout.ts
+++ b/src/decorators/logout.ts
@@ -6,7 +6,7 @@ import { FastifyRequest } from 'fastify'
  * @api public
  */
 export async function logOut(this: FastifyRequest): Promise<void> {
-  const property = this.passport.userProperty || 'user'
+  const property = this.passport.userProperty
   this[property] = null
   await this.passport.sessionManager.logOut(this)
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,4 @@
-import Authenticator from './Authenticator'
+import { Authenticator } from './Authenticator'
 import './type-extensions' // necessary to make sure that the fastify types are augmented
 const passport = new Authenticator()
 
@@ -6,3 +6,4 @@ const passport = new Authenticator()
 module.exports = exports = passport
 export default passport
 export { Strategy } from './strategies'
+export { Authenticator } from './Authenticator'

--- a/src/strategies/SessionStrategy.ts
+++ b/src/strategies/SessionStrategy.ts
@@ -51,8 +51,7 @@ export class SessionStrategy extends Strategy {
           if (!user) {
             await request.passport.sessionManager.logOut(request)
           } else {
-            const property = request.passport.userProperty || 'user'
-            request[property] = user
+            request[request.passport.userProperty] = user
           }
           this.pass()
         })

--- a/test/multi-instance.test.ts
+++ b/test/multi-instance.test.ts
@@ -1,0 +1,220 @@
+import { FastifyInstance } from 'fastify'
+import { getTestServer, TestBrowserSession, TestStrategy } from './helpers'
+import { Authenticator } from '../src/Authenticator'
+
+describe('multiple registered instances', () => {
+  let server: FastifyInstance
+  let authenticators: Record<string, Authenticator>
+  let session: TestBrowserSession
+
+  beforeEach(async () => {
+    server = getTestServer()
+    authenticators = {}
+    session = new TestBrowserSession(server)
+
+    for (const name of ['a', 'b']) {
+      const strategyName = `test-${name}`
+      await server.register(async (instance) => {
+        const authenticator = new Authenticator({ key: name, userProperty: `user${name}` })
+        authenticator.use(strategyName, new TestStrategy(strategyName))
+        authenticator.registerUserSerializer(async (user) => JSON.stringify(user))
+        authenticator.registerUserDeserializer(async (serialized: string) => JSON.parse(serialized))
+
+        await instance.register(authenticator.initialize())
+        await instance.register(authenticator.secureSession())
+        authenticators[name] = authenticator
+
+        instance.get(
+          `/${name}`,
+          { preValidation: authenticator.authenticate(strategyName, { authInfo: false }) },
+          async () => `hello ${name}!`
+        )
+
+        instance.get(
+          `/user/${name}`,
+          { preValidation: authenticator.authenticate(strategyName, { authInfo: false }) },
+          async (request) => JSON.stringify(request[`user${name}`])
+        )
+
+        instance.post(
+          `/login-${name}`,
+          { preValidation: authenticator.authenticate(strategyName, { successRedirect: `/${name}`, authInfo: false }) },
+          () => {
+            return
+          }
+        )
+
+        instance.post(
+          `/logout-${name}`,
+          { preValidation: authenticator.authenticate(strategyName, { authInfo: false }) },
+          async (request, reply) => {
+            await request.logout()
+            void reply.send('logged out')
+          }
+        )
+      })
+    }
+  })
+
+  test('logging in with one instance should not log in the other instance', async () => {
+    let response = await session.inject({ method: 'GET', url: '/a' })
+    expect(response.body).toEqual('Unauthorized')
+    expect(response.statusCode).toEqual(401)
+
+    response = await session.inject({ method: 'GET', url: '/b' })
+    expect(response.body).toEqual('Unauthorized')
+    expect(response.statusCode).toEqual(401)
+
+    // login a
+    const loginResponse = await session.inject({
+      method: 'POST',
+      url: '/login-a',
+      payload: { login: 'test', password: 'test' },
+    })
+
+    expect(loginResponse.statusCode).toEqual(302)
+    expect(loginResponse.headers.location).toEqual('/a')
+
+    // access protected route
+    response = await session.inject({
+      method: 'GET',
+      url: '/a',
+    })
+    expect(response.statusCode).toEqual(200)
+    expect(response.body).toEqual('hello a!')
+
+    // access user data
+    response = await session.inject({
+      method: 'GET',
+      url: '/user/a',
+    })
+    expect(response.statusCode).toEqual(200)
+
+    // try to access route protected by other instance
+    response = await session.inject({
+      method: 'GET',
+      url: '/b',
+    })
+    expect(response.statusCode).toEqual(401)
+  })
+
+  test('simultaneous login should be possible', async () => {
+    // login a
+    let response = await session.inject({
+      method: 'POST',
+      url: '/login-a',
+      payload: { login: 'test', password: 'test' },
+    })
+
+    expect(response.statusCode).toEqual(302)
+    expect(response.headers.location).toEqual('/a')
+
+    // login b
+    response = await session.inject({
+      method: 'POST',
+      url: '/login-b',
+      payload: { login: 'test', password: 'test' },
+    })
+
+    expect(response.statusCode).toEqual(302)
+    expect(response.headers.location).toEqual('/b')
+
+    // access a protected route
+    response = await session.inject({
+      method: 'GET',
+      url: '/a',
+    })
+    expect(response.statusCode).toEqual(200)
+    expect(response.body).toEqual('hello a!')
+
+    // access b protected route
+    response = await session.inject({
+      method: 'GET',
+      url: '/b',
+    })
+    expect(response.statusCode).toEqual(200)
+    expect(response.body).toEqual('hello b!')
+  })
+
+  test('logging out with one instance should not log out the other instance', async () => {
+    // login a
+    let response = await session.inject({
+      method: 'POST',
+      url: '/login-a',
+      payload: { login: 'test', password: 'test' },
+    })
+
+    expect(response.statusCode).toEqual(302)
+    expect(response.headers.location).toEqual('/a')
+
+    // login b
+    response = await session.inject({
+      method: 'POST',
+      url: '/login-b',
+      payload: { login: 'test', password: 'test' },
+    })
+
+    expect(response.statusCode).toEqual(302)
+    expect(response.headers.location).toEqual('/b')
+
+    // logout a
+    response = await session.inject({
+      method: 'POST',
+      url: '/logout-a',
+    })
+    expect(response.statusCode).toEqual(200)
+
+    // try to access route protected by now logged out instance
+    response = await session.inject({
+      method: 'GET',
+      url: '/a',
+    })
+    expect(response.statusCode).toEqual(401)
+
+    // access b protected route which should still be logged in
+    response = await session.inject({
+      method: 'GET',
+      url: '/b',
+    })
+    expect(response.statusCode).toEqual(200)
+    expect(response.body).toEqual('hello b!')
+  })
+
+  test('user objects from different instances should be different', async () => {
+    // login a
+    let response = await session.inject({
+      method: 'POST',
+      url: '/login-a',
+      payload: { login: 'test', password: 'test' },
+    })
+
+    expect(response.statusCode).toEqual(302)
+    expect(response.headers.location).toEqual('/a')
+
+    // login b
+    response = await session.inject({
+      method: 'POST',
+      url: '/login-b',
+      payload: { login: 'test', password: 'test' },
+    })
+
+    expect(response.statusCode).toEqual(302)
+    expect(response.headers.location).toEqual('/b')
+
+    response = await session.inject({
+      method: 'GET',
+      url: '/user/a',
+    })
+    expect(response.statusCode).toEqual(200)
+    const userA = JSON.parse(response.body)
+
+    response = await session.inject({
+      method: 'GET',
+      url: '/user/b',
+    })
+    expect(response.statusCode).toEqual(200)
+    const userB = JSON.parse(response.body)
+
+    expect(userA.id).not.toEqual(userB.id)
+  })
+})


### PR DESCRIPTION
#### Checklist

- [X] run `npm run test` and `npm run benchmark`
- [X] tests and/or benchmarks are included
- [X] documentation is changed or added
- [X] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)


This adds support for registering `fastify-passport` more than once in the same application, where each instance stores its logged in user at a different decorated property on the request. This is useful for adding say an admin only area to an application that already has user login set up. 