### PR TITLE
Add support for authenticating with already-instantiated strategies.

### DIFF
--- a/src/Authenticator.ts
+++ b/src/Authenticator.ts
@@ -1,5 +1,5 @@
 import { SecureSessionManager } from './session-managers/SecureSessionManager'
-import { AnyStrategy, SessionStrategy } from './strategies'
+import { AnyStrategy, SessionStrategy, Strategy } from './strategies'
 import { FastifyRequest, RouteHandlerMethod, FastifyPlugin } from 'fastify'
 import { AuthenticateOptions, AuthenticateCallback, AuthenticationRoute } from './AuthenticationRoute'
 import { CreateInitializePlugin } from './CreateInitializePlugin'
@@ -131,23 +131,23 @@ export class Authenticator {
    * @api public
    */
 
-  public authenticate<StrategyName extends string | string[]>(
-    strategy: StrategyName,
-    callback?: AuthenticateCallback<StrategyName>
+  public authenticate<StrategyOrStrategies extends string | Strategy | (string | Strategy)[]>(
+    strategy: StrategyOrStrategies,
+    callback?: AuthenticateCallback<StrategyOrStrategies>
   ): RouteHandlerMethod
-  public authenticate<StrategyName extends string | string[]>(
-    strategy: StrategyName,
+  public authenticate<StrategyOrStrategies extends string | Strategy | (string | Strategy)[]>(
+    strategy: StrategyOrStrategies,
     options?: AuthenticateOptions
   ): RouteHandlerMethod
-  public authenticate<StrategyName extends string | string[]>(
-    strategy: StrategyName,
+  public authenticate<StrategyOrStrategies extends string | Strategy | (string | Strategy)[]>(
+    strategy: StrategyOrStrategies,
     options?: AuthenticateOptions,
-    callback?: AuthenticateCallback<StrategyName>
+    callback?: AuthenticateCallback<StrategyOrStrategies>
   ): RouteHandlerMethod
-  public authenticate<StrategyName extends string | string[]>(
-    strategyOrStrategies: StrategyName,
-    optionsOrCallback?: AuthenticateOptions | AuthenticateCallback<StrategyName>,
-    callback?: AuthenticateCallback<StrategyName>
+  public authenticate<StrategyOrStrategies extends string | Strategy | (string | Strategy)[]>(
+    strategyOrStrategies: StrategyOrStrategies,
+    optionsOrCallback?: AuthenticateOptions | AuthenticateCallback<StrategyOrStrategies>,
+    callback?: AuthenticateCallback<StrategyOrStrategies>
   ): RouteHandlerMethod {
     let options
     if (typeof optionsOrCallback == 'function') {
@@ -177,20 +177,23 @@ export class Authenticator {
    * @api public
    */
 
-  public authorize<StrategyName extends string | string[]>(
-    strategy: StrategyName,
-    callback?: AuthenticateCallback<StrategyName>
+  public authorize<StrategyOrStrategies extends string | Strategy | (string | Strategy)[]>(
+    strategy: StrategyOrStrategies,
+    callback?: AuthenticateCallback<StrategyOrStrategies>
   )
-  public authorize<StrategyName extends string | string[]>(strategy: StrategyName, options?: AuthenticateOptions)
-  public authorize<StrategyName extends string | string[]>(
-    strategy: StrategyName,
+  public authorize<StrategyOrStrategies extends string | Strategy | (string | Strategy)[]>(
+    strategy: StrategyOrStrategies,
+    options?: AuthenticateOptions
+  )
+  public authorize<StrategyOrStrategies extends string | Strategy | (string | Strategy)[]>(
+    strategy: StrategyOrStrategies,
     options?: AuthenticateOptions,
-    callback?: AuthenticateCallback<StrategyName>
+    callback?: AuthenticateCallback<StrategyOrStrategies>
   )
-  public authorize<StrategyName extends string | string[]>(
-    strategyOrStrategies: StrategyName,
-    optionsOrCallback?: AuthenticateOptions | AuthenticateCallback<StrategyName>,
-    callback?: AuthenticateCallback<StrategyName>
+  public authorize<StrategyOrStrategies extends string | Strategy | (string | Strategy)[]>(
+    strategyOrStrategies: StrategyOrStrategies,
+    optionsOrCallback?: AuthenticateOptions | AuthenticateCallback<StrategyOrStrategies>,
+    callback?: AuthenticateCallback<StrategyOrStrategies>
   ) {
     let options
     if (typeof optionsOrCallback == 'function') {

--- a/test/helpers.ts
+++ b/test/helpers.ts
@@ -70,6 +70,7 @@ export class TestBrowserSession {
   }
 }
 
+/** Create a fastify instance with a few simple setup bits added, but without fastify-passport registered or any strategies set up. */
 export const getTestServer = () => {
   const server = fastify()
   void server.register(fastifySecureSession, { key: SecretKey })
@@ -81,9 +82,9 @@ export const getTestServer = () => {
   return server
 }
 
-export const getConfiguredTestServer = (name = 'test', strategy = new TestStrategy('test')) => {
+/** Create a fastify instance with fastify-passport plugin registered but with no strategies registered yet. */
+export const getRegisteredTestServer = () => {
   const fastifyPassport = new Authenticator()
-  fastifyPassport.use(name, strategy)
   fastifyPassport.registerUserSerializer(async (user) => JSON.stringify(user))
   fastifyPassport.registerUserDeserializer(async (serialized: string) => JSON.parse(serialized))
 
@@ -91,5 +92,12 @@ export const getConfiguredTestServer = (name = 'test', strategy = new TestStrate
   void server.register(fastifyPassport.initialize())
   void server.register(fastifyPassport.secureSession())
 
+  return { fastifyPassport, server }
+}
+
+/** Create a fastify instance with fastify-passport plugin registered and the given strategy registered with it. */
+export const getConfiguredTestServer = (name = 'test', strategy = new TestStrategy('test')) => {
+  const { fastifyPassport, server } = getRegisteredTestServer()
+  fastifyPassport.use(name, strategy)
   return { fastifyPassport, server }
 }

--- a/test/independent-strategy-instances.test.ts
+++ b/test/independent-strategy-instances.test.ts
@@ -1,0 +1,171 @@
+/* eslint-disable @typescript-eslint/no-empty-function */
+import { getConfiguredTestServer, getRegisteredTestServer, TestStrategy } from './helpers'
+import { Strategy } from '../src/strategies'
+import { TestThirdPartyStrategy } from './authorize.test'
+
+class WelcomeStrategy extends Strategy {
+  authenticate(request: any, _options?: { pauseStream?: boolean }) {
+    if (request.isAuthenticated()) {
+      return this.pass()
+    }
+    if (request.body && request.body.login === 'welcomeuser' && request.body.password === 'test') {
+      return this.success({ name: 'test' }, { message: 'welcome from strategy' })
+    }
+    this.fail()
+  }
+}
+
+test(`should allow passing a specific Strategy instance to an authenticate call`, async () => {
+  const { server, fastifyPassport } = getRegisteredTestServer()
+  server.get(
+    '/',
+    {
+      preValidation: fastifyPassport.authenticate(new WelcomeStrategy('welcome'), { authInfo: false }),
+    },
+    async (request) => request.session.get('messages')
+  )
+  server.post(
+    '/login',
+    {
+      preValidation: fastifyPassport.authenticate(new WelcomeStrategy('welcome'), {
+        successRedirect: '/',
+        successMessage: true,
+        authInfo: false,
+      }),
+    },
+    () => {}
+  )
+
+  const login = await server.inject({
+    method: 'POST',
+    payload: { login: 'welcomeuser', password: 'test' },
+    url: '/login',
+  })
+  expect(login.statusCode).toEqual(302)
+  expect(login.headers.location).toEqual('/')
+
+  const response = await server.inject({
+    url: '/',
+    headers: {
+      cookie: login.headers['set-cookie'],
+    },
+    method: 'GET',
+  })
+
+  expect(response.body).toEqual('["welcome from strategy"]')
+  expect(response.statusCode).toEqual(200)
+})
+
+test(`should allow passing a multiple specific Strategy instances to an authenticate call`, async () => {
+  const { server, fastifyPassport } = getRegisteredTestServer()
+  server.get(
+    '/',
+    {
+      preValidation: fastifyPassport.authenticate([new WelcomeStrategy('welcome'), new TestStrategy('test')], {
+        authInfo: false,
+      }),
+    },
+    async (request) => `messages: ${request.session.get('messages')}`
+  )
+  server.post(
+    '/login',
+    {
+      preValidation: fastifyPassport.authenticate([new WelcomeStrategy('welcome'), new TestStrategy('test')], {
+        successRedirect: '/',
+        successMessage: true,
+        authInfo: false,
+      }),
+    },
+    () => {}
+  )
+
+  const login = await server.inject({
+    method: 'POST',
+    payload: { login: 'test', password: 'test' },
+    url: '/login',
+  })
+  expect(login.statusCode).toEqual(302)
+  expect(login.headers.location).toEqual('/')
+
+  const response = await server.inject({
+    url: '/',
+    headers: {
+      cookie: login.headers['set-cookie'],
+    },
+    method: 'GET',
+  })
+
+  expect(response.body).toEqual('messages: undefined')
+  expect(response.statusCode).toEqual(200)
+})
+
+test(`should allow passing a mix of Strategy instances and strategy names`, async () => {
+  const { server, fastifyPassport } = getConfiguredTestServer()
+  server.get(
+    '/',
+    {
+      preValidation: fastifyPassport.authenticate([new WelcomeStrategy('welcome'), 'test'], {
+        authInfo: false,
+      }),
+    },
+    async (request) => `messages: ${request.session.get('messages')}`
+  )
+  server.post(
+    '/login',
+    {
+      preValidation: fastifyPassport.authenticate([new WelcomeStrategy('welcome'), 'test'], {
+        successRedirect: '/',
+        successMessage: true,
+        authInfo: false,
+      }),
+    },
+    () => {}
+  )
+
+  const login = await server.inject({
+    method: 'POST',
+    payload: { login: 'test', password: 'test' },
+    url: '/login',
+  })
+  expect(login.statusCode).toEqual(302)
+  expect(login.headers.location).toEqual('/')
+
+  const response = await server.inject({
+    url: '/',
+    headers: {
+      cookie: login.headers['set-cookie'],
+    },
+    method: 'GET',
+  })
+
+  expect(response.body).toEqual('messages: undefined')
+  expect(response.statusCode).toEqual(200)
+})
+
+test(`should allow passing specific instances to an authorize call`, async () => {
+  const { server, fastifyPassport } = getConfiguredTestServer()
+
+  server.get(
+    '/',
+    { preValidation: fastifyPassport.authorize(new TestThirdPartyStrategy('third-party')) },
+    async (request) => {
+      const user = request.user as any
+      expect(user).toBeFalsy()
+      const account = request.account as any
+      expect(account.id).toBeTruthy()
+      expect(account.name).toEqual('test')
+
+      return 'it worked'
+    }
+  )
+
+  const response = await server.inject({ method: 'GET', url: '/' })
+  expect(response.statusCode).toEqual(200)
+})
+
+test(`Strategy instances used during one authentication shouldn't be registered`, async () => {
+  const { fastifyPassport } = getRegisteredTestServer()
+  // build a handler with the welcome strategy
+  fastifyPassport.authenticate(new WelcomeStrategy('welcome'), { authInfo: false })
+  expect(fastifyPassport.strategy('welcome')).toBeUndefined()
+})


### PR DESCRIPTION
This allows for running authentication with ephemeral strategies you don't want to register into the global namespace, or for simultaneous asynchronous authentications using the same strategy with different configurations. My use case specifically is that I want some users of my application to bring their own credentials -- instead of using one fixed oauth access token for a given integration, users should be able to supply their own, and we'll use it at runtime instead of the fixed one.

This means that for a given request we need to be able to use either the fixed strategy registered with the authenticator at server boot, or an ephemeral one created using the request context for just that request. It's important that the strategy not be registered into the global list of strategies so it doesn't stomp on the strategy with the same name, or leak memory if given a different name.

Most of this change is just TypeScript types and tests -- only one small implementation change to only sometimes instantiate the sent in strategies by name.

#### Checklist

- [X] run `npm run test` and `npm run benchmark`
- [X] tests and/or benchmarks are included
- [X] documentation is changed or added
- [X] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
