### PR TITLE
chore: build and dependabot improvements

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -2,10 +2,6 @@ version: 2
 updates:
   - package-ecosystem: github-actions
     directory: '/'
-    ignore:
-      - dependency-name: "actions/*"
-        update-types:
-            ["version-update:semver-minor", "version-update:semver-patch"]
     schedule:
       interval: daily
     open-pull-requests-limit: 10

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [12.x, 14.x]
+        node-version: [12, 14, 16]
         os: [macos-latest, ubuntu-latest, windows-latest]
 
     steps:
@@ -26,13 +26,7 @@ jobs:
         uses: actions/setup-node@v2
         with:
           node-version: ${{ matrix.node-version }}
-
-      - uses: actions/cache@v2.1.7
-        with:
-          path: ~/.npm
-          key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}
-          restore-keys: |
-            ${{ runner.os }}-node-
+          cache: 'npm'
 
       - name: Install
         run: npm install --ignore-scripts --frozen-lockfile
@@ -47,7 +41,7 @@ jobs:
       pull-requests: write
       contents: write
     steps:
-      - uses: fastify/github-action-merge-dependabot@v3.0.2
+      - uses: fastify/github-action-merge-dependabot@v3
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
 


### PR DESCRIPTION
This PR contains various improvements around dependabot and the build:

- use Node shorthand for CI
- add Node 16 to CI
- use setup-node action builtin cache
- use automerge action v3. this is to avoid too many dependabot bumps to github actions
- remove unnecessary ignores in dependabot config file: when referencing semver major/minor/whatever, dependabot will already use whatever is latest within the specified range. i.e if you use action@v3, dependabot will us whatever v3 is latest (e.g. v3.0.2)

All the above changes could be made throughout the whole set of plugins. I know that some time ago @Fdawgs did the dependabot ignore change across many repos. Now that change turned out to be unnecessary.