### PR TITLE
feat: openid-client support

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -29,6 +29,7 @@
         "fastify": "^4.0.0-rc.2",
         "got": "^11.8.1",
         "jest": "^27.0.6",
+        "openid-client": "^5.1.6",
         "passport-facebook": "^3.0.0",
         "passport-github2": "^0.1.12",
         "passport-google-oauth": "^2.0.0",
@@ -4527,6 +4528,15 @@
         "url": "https://github.com/chalk/supports-color?sponsor=1"
       }
     },
+    "node_modules/jose": {
+      "version": "4.8.1",
+      "resolved": "https://registry.npmjs.org/jose/-/jose-4.8.1.tgz",
+      "integrity": "sha512-+/hpTbRcCw9YC0TOfN1W47pej4a9lRmltdOVdRLz5FP5UvUq3CenhXjQK7u/8NdMIIShMXYAh9VLPhc7TjhvFw==",
+      "dev": true,
+      "funding": {
+        "url": "https://github.com/sponsors/panva"
+      }
+    },
     "node_modules/js-tokens": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
@@ -4978,6 +4988,24 @@
       "integrity": "sha1-vR/vr2hslrdUda7VGWQS/2DPucE=",
       "dev": true
     },
+    "node_modules/object-hash": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/object-hash/-/object-hash-2.2.0.tgz",
+      "integrity": "sha512-gScRMn0bS5fH+IuwyIFgnh9zBdo4DV+6GhygmWM9HyNJSgS0hScp1f5vjtm7oIIOiT9trXrShAkLFSc2IqKNgw==",
+      "dev": true,
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/oidc-token-hash": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/oidc-token-hash/-/oidc-token-hash-5.0.1.tgz",
+      "integrity": "sha512-EvoOtz6FIEBzE+9q253HsLCVRiK/0doEJ2HCvvqMQb3dHZrP3WlJKYtJ55CRTw4jmYomzH4wkPuCj/I3ZvpKxQ==",
+      "dev": true,
+      "engines": {
+        "node": "^10.13.0 || >=12.0.0"
+      }
+    },
     "node_modules/on-exit-leak-free": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/on-exit-leak-free/-/on-exit-leak-free-1.0.0.tgz",
@@ -5006,6 +5034,24 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/openid-client": {
+      "version": "5.1.6",
+      "resolved": "https://registry.npmjs.org/openid-client/-/openid-client-5.1.6.tgz",
+      "integrity": "sha512-HTFaXWdUHvLFw4GaEMgC0jXYBgpjgzQQNHW1pZsSqJorSgrXzxJ+4u/LWCGaClDEse5HLjXRV+zU5Bn3OefiZw==",
+      "dev": true,
+      "dependencies": {
+        "jose": "^4.1.4",
+        "lru-cache": "^6.0.0",
+        "object-hash": "^2.0.1",
+        "oidc-token-hash": "^5.0.1"
+      },
+      "engines": {
+        "node": "^12.19.0 || ^14.15.0 || ^16.13.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/panva"
       }
     },
     "node_modules/optionator": {
@@ -10008,6 +10054,12 @@
         }
       }
     },
+    "jose": {
+      "version": "4.8.1",
+      "resolved": "https://registry.npmjs.org/jose/-/jose-4.8.1.tgz",
+      "integrity": "sha512-+/hpTbRcCw9YC0TOfN1W47pej4a9lRmltdOVdRLz5FP5UvUq3CenhXjQK7u/8NdMIIShMXYAh9VLPhc7TjhvFw==",
+      "dev": true
+    },
     "js-tokens": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
@@ -10368,6 +10420,18 @@
       "integrity": "sha1-vR/vr2hslrdUda7VGWQS/2DPucE=",
       "dev": true
     },
+    "object-hash": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/object-hash/-/object-hash-2.2.0.tgz",
+      "integrity": "sha512-gScRMn0bS5fH+IuwyIFgnh9zBdo4DV+6GhygmWM9HyNJSgS0hScp1f5vjtm7oIIOiT9trXrShAkLFSc2IqKNgw==",
+      "dev": true
+    },
+    "oidc-token-hash": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/oidc-token-hash/-/oidc-token-hash-5.0.1.tgz",
+      "integrity": "sha512-EvoOtz6FIEBzE+9q253HsLCVRiK/0doEJ2HCvvqMQb3dHZrP3WlJKYtJ55CRTw4jmYomzH4wkPuCj/I3ZvpKxQ==",
+      "dev": true
+    },
     "on-exit-leak-free": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/on-exit-leak-free/-/on-exit-leak-free-1.0.0.tgz",
@@ -10390,6 +10454,18 @@
       "dev": true,
       "requires": {
         "mimic-fn": "^2.1.0"
+      }
+    },
+    "openid-client": {
+      "version": "5.1.6",
+      "resolved": "https://registry.npmjs.org/openid-client/-/openid-client-5.1.6.tgz",
+      "integrity": "sha512-HTFaXWdUHvLFw4GaEMgC0jXYBgpjgzQQNHW1pZsSqJorSgrXzxJ+4u/LWCGaClDEse5HLjXRV+zU5Bn3OefiZw==",
+      "dev": true,
+      "requires": {
+        "jose": "^4.1.4",
+        "lru-cache": "^6.0.0",
+        "object-hash": "^2.0.1",
+        "oidc-token-hash": "^5.0.1"
       }
     },
     "optionator": {

--- a/package.json
+++ b/package.json
@@ -57,6 +57,7 @@
     "fastify": "^4.0.0-rc.2",
     "got": "^11.8.1",
     "jest": "^27.0.6",
+    "openid-client": "^5.1.6",
     "passport-facebook": "^3.0.0",
     "passport-github2": "^0.1.12",
     "passport-google-oauth": "^2.0.0",

--- a/test/strategies-integration.test.ts
+++ b/test/strategies-integration.test.ts
@@ -1,6 +1,7 @@
 import { Strategy as FacebookStrategy } from 'passport-facebook'
 import { Strategy as GitHubStrategy } from 'passport-github2'
 import { OAuth2Strategy as GoogleStrategy } from 'passport-google-oauth'
+import { Issuer as OpenIdIssuer, Strategy as OpenIdStrategy } from 'openid-client'
 import { getConfiguredTestServer, TestStrategy } from './helpers'
 
 const suite = (sessionPluginName) => {
@@ -79,6 +80,39 @@ const suite = (sessionPluginName) => {
       server.post(
         '/login',
         { preValidation: fastifyPassport.authenticate('github', { authInfo: false }) },
+        async () => 'hello'
+      )
+
+      const response = await server.inject({ method: 'GET', url: '/' })
+      expect(response.statusCode).toEqual(302)
+    })
+
+    test('should initiate oauth with the openid-client strategy from npm', async () => {
+      const issuer = new OpenIdIssuer({ issuer: 'test_issuer', authorization_endpoint: 'www.example.com' })
+
+      const client = new issuer.Client({
+        client_id: 'identifier',
+        client_secret: 'secure',
+        redirect_uris: ['http://www.example.com/auth/openid-client/callback'],
+      })
+
+      const strategy = new OpenIdStrategy(
+        {
+          client,
+        },
+        () => fail()
+      ) as TestStrategy
+
+      const { server, fastifyPassport } = getConfiguredTestServer('openid-client', strategy)
+
+      server.get(
+        '/',
+        { preValidation: fastifyPassport.authenticate('openid-client', { authInfo: false }) },
+        async () => 'hello world!'
+      )
+      server.post(
+        '/login',
+        { preValidation: fastifyPassport.authenticate('openid-client', { authInfo: false }) },
         async () => 'hello'
       )
 


### PR DESCRIPTION
Adds a test to show that this works with node-openid-client passport strategy.

Supersedes #535 

Closes #491

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
