### PR TITLE
Catch unexpected errors during strategy execution and dispatch through the fastify error stack

### DIFF
--- a/src/strategies/base.ts
+++ b/src/strategies/base.ts
@@ -9,14 +9,14 @@ export class Strategy {
   /**
    * Authenticate request.
    *
-   * This function must be overridden by subclasses.  In abstract form, it always
+   * This function must be overridden by subclasses. In abstract form, it always
    * throws an exception.
    *
    * @param {Object} req The request to authenticate.
    * @param {Object} [options] Strategy-specific options.
    * @api public
    */
-  authenticate(request: FastifyRequest, options?: any): void
+  authenticate(request: FastifyRequest, options?: any): void | Promise<void>
   authenticate() {
     throw new Error('Strategy#authenticate must be overridden by subclass')
   }


### PR DESCRIPTION
Before this change, strategies that throw errors (or return promises which throw errors) wouldn't trigger the fastify error handling. Strategies which returned promises that then rejected would trigger uncaughPromiseRejection events as well.

This issue stems from the strange API that passport requires for strategies born in the callback era, where strategies get told to run and are expected to call back into the fastify-passport handling by calling `this.error` or `this.success` or what have you. If the strategy throws unexpectedly though, we didn't catch that and now we do.
