### PR TITLE
use tsconfig node 14

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,6 +16,7 @@
         "@fastify/cookie": "^7.0.0",
         "@fastify/secure-session": "^5.0.0",
         "@fastify/session": "^9.0.0",
+        "@tsconfig/node14": "^1.0.3",
         "@types/jest": "^27.0.0",
         "@types/node": "^18.0.0",
         "@types/passport": "^1.0.5",
@@ -1199,6 +1200,12 @@
       "engines": {
         "node": ">= 6"
       }
+    },
+    "node_modules/@tsconfig/node14": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node14/-/node14-1.0.3.tgz",
+      "integrity": "sha512-ysT8mhdixWK6Hw3i1V2AeRqZ5WfXg1G43mqoYlM2nc6388Fq5jcXyr5mRsqViLx/GJYdoL0bfXD8nmF+Zn/Iow==",
+      "dev": true
     },
     "node_modules/@types/babel__core": {
       "version": "7.1.18",
@@ -7496,6 +7503,12 @@
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/@tootallnate/once/-/once-1.1.2.tgz",
       "integrity": "sha512-RbzJvlNzmRq5c3O09UipeuXno4tA1FE6ikOjxZK0tuxVv3412l64l5t1W5pj4+rJq9vpkm/kwiR07aZXnsKPxw==",
+      "dev": true
+    },
+    "@tsconfig/node14": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node14/-/node14-1.0.3.tgz",
+      "integrity": "sha512-ysT8mhdixWK6Hw3i1V2AeRqZ5WfXg1G43mqoYlM2nc6388Fq5jcXyr5mRsqViLx/GJYdoL0bfXD8nmF+Zn/Iow==",
       "dev": true
     },
     "@types/babel__core": {

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "scripts": {
-    "build": "rimraf ./dist && mkdir dist && tsc --outDir dist && git rev-parse HEAD > BUILD_SHA",
+    "build": "rimraf ./dist && tsc",
     "lint": "eslint \"*/**/*.{js,ts,tsx}\"",
     "lint:fix": "prettier --loglevel warn --write \"src/**/*.{ts,tsx}\" && eslint \"*/**/*.{js,ts,tsx}\" --quiet --fix",
     "prepublishOnly": "npm run build",
@@ -44,6 +44,7 @@
     "@fastify/cookie": "^7.0.0",
     "@fastify/secure-session": "^5.0.0",
     "@fastify/session": "^9.0.0",
+    "@tsconfig/node14": "^1.0.3",
     "@types/jest": "^27.0.0",
     "@types/node": "^18.0.0",
     "@types/passport": "^1.0.5",

--- a/src/Authenticator.ts
+++ b/src/Authenticator.ts
@@ -1,4 +1,4 @@
-import { FastifyPlugin, FastifyReply, FastifyRequest, RouteHandlerMethod } from 'fastify'
+import { FastifyPlugin, FastifyRequest, RouteHandlerMethod } from 'fastify'
 import fastifyPlugin from 'fastify-plugin'
 import { AuthenticateCallback, AuthenticateOptions, AuthenticationRoute } from './AuthenticationRoute'
 import { CreateInitializePlugin } from './CreateInitializePlugin'
@@ -180,21 +180,21 @@ export class Authenticator {
   public authorize<StrategyOrStrategies extends string | Strategy | (string | Strategy)[]>(
     strategy: StrategyOrStrategies,
     callback?: AuthenticateCallback<StrategyOrStrategies>
-  ): (request: FastifyRequest, reply: FastifyReply) => Promise<void>
+  ): RouteHandlerMethod
   public authorize<StrategyOrStrategies extends string | Strategy | (string | Strategy)[]>(
     strategy: StrategyOrStrategies,
     options?: AuthenticateOptions
-  ): (request: FastifyRequest, reply: FastifyReply) => Promise<void>
+  ): RouteHandlerMethod
   public authorize<StrategyOrStrategies extends string | Strategy | (string | Strategy)[]>(
     strategy: StrategyOrStrategies,
     options?: AuthenticateOptions,
     callback?: AuthenticateCallback<StrategyOrStrategies>
-  ): (request: FastifyRequest, reply: FastifyReply) => Promise<void>
+  ): RouteHandlerMethod
   public authorize<StrategyOrStrategies extends string | Strategy | (string | Strategy)[]>(
     strategyOrStrategies: StrategyOrStrategies,
     optionsOrCallback?: AuthenticateOptions | AuthenticateCallback<StrategyOrStrategies>,
     callback?: AuthenticateCallback<StrategyOrStrategies>
-  ): (request: FastifyRequest, reply: FastifyReply) => Promise<void> {
+  ): RouteHandlerMethod {
     let options: AuthenticateOptions | undefined
     if (typeof optionsOrCallback == 'function') {
       options = {}

--- a/src/Authenticator.ts
+++ b/src/Authenticator.ts
@@ -1,4 +1,4 @@
-import { FastifyPlugin, FastifyRequest, RouteHandlerMethod } from 'fastify'
+import { FastifyPlugin, FastifyReply, FastifyRequest, RouteHandlerMethod } from 'fastify'
 import fastifyPlugin from 'fastify-plugin'
 import { AuthenticateCallback, AuthenticateOptions, AuthenticationRoute } from './AuthenticationRoute'
 import { CreateInitializePlugin } from './CreateInitializePlugin'
@@ -180,21 +180,21 @@ export class Authenticator {
   public authorize<StrategyOrStrategies extends string | Strategy | (string | Strategy)[]>(
     strategy: StrategyOrStrategies,
     callback?: AuthenticateCallback<StrategyOrStrategies>
-  )
+  ): (request: FastifyRequest, reply: FastifyReply) => Promise<void>
   public authorize<StrategyOrStrategies extends string | Strategy | (string | Strategy)[]>(
     strategy: StrategyOrStrategies,
     options?: AuthenticateOptions
-  )
+  ): (request: FastifyRequest, reply: FastifyReply) => Promise<void>
   public authorize<StrategyOrStrategies extends string | Strategy | (string | Strategy)[]>(
     strategy: StrategyOrStrategies,
     options?: AuthenticateOptions,
     callback?: AuthenticateCallback<StrategyOrStrategies>
-  )
+  ): (request: FastifyRequest, reply: FastifyReply) => Promise<void>
   public authorize<StrategyOrStrategies extends string | Strategy | (string | Strategy)[]>(
     strategyOrStrategies: StrategyOrStrategies,
     optionsOrCallback?: AuthenticateOptions | AuthenticateCallback<StrategyOrStrategies>,
     callback?: AuthenticateCallback<StrategyOrStrategies>
-  ) {
+  ): (request: FastifyRequest, reply: FastifyReply) => Promise<void> {
     let options: AuthenticateOptions | undefined
     if (typeof optionsOrCallback == 'function') {
       options = {}

--- a/test/helpers.ts
+++ b/test/helpers.ts
@@ -6,7 +6,7 @@ import fastifySession from '@fastify/session'
 import Authenticator from '../src/Authenticator'
 import { Strategy } from '../src/strategies'
 import { InjectOptions, Response as LightMyRequestResponse } from 'light-my-request'
-import * as parseCookies from 'set-cookie-parser'
+import parseCookies from 'set-cookie-parser'
 import { IncomingMessage } from 'http'
 import { FastifyRegisterOptions } from 'fastify/types/register'
 import FastifySessionPlugin from '@fastify/session'
@@ -99,7 +99,6 @@ export const getTestServer = (sessionOptions: SessionOptions = null) => {
   loadSessionPlugins(server, sessionOptions)
 
   server.setErrorHandler((error, request, reply) => {
-    console.error(error)
     void reply.status(500)
     void reply.send(error)
   })

--- a/test/helpers.ts
+++ b/test/helpers.ts
@@ -99,6 +99,7 @@ export const getTestServer = (sessionOptions: SessionOptions = null) => {
   loadSessionPlugins(server, sessionOptions)
 
   server.setErrorHandler((error, request, reply) => {
+    console.error(error)
     void reply.status(500)
     void reply.send(error)
   })

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,12 +1,11 @@
 {
+  "extends": "@tsconfig/node14/tsconfig.json",
   "compilerOptions": {
     "moduleResolution": "node",
     "declaration": true,
-    "target": "es2017",
-    "module": "commonjs",
+    "outDir": "dist",
     "pretty": true,
     "noEmitOnError": true,
-    "strict": true,
     "noImplicitAny": false,
     "removeComments": true,
     "noUnusedLocals": true,


### PR DESCRIPTION
If we someday drop node 14, we just need to change the tsconfig.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/fastify/fastify/blob/master/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
