### PR TITLE
Fix misleading types

### DIFF
--- a/src/Authenticator.ts
+++ b/src/Authenticator.ts
@@ -259,7 +259,7 @@ export class Authenticator {
    *
    * @api public
    */
-  registerUserSerializer<TUser, TID>(fn: SerializeFunction<TUser, TID>) {
+  registerUserSerializer<User, StoredUser>(fn: SerializeFunction<User, StoredUser>) {
     this.serializers.push(fn)
   }
 
@@ -285,7 +285,7 @@ export class Authenticator {
    *
    * @api public
    */
-  registerUserDeserializer<User, StoredUser>(fn: DeserializeFunction<User, StoredUser>) {
+  registerUserDeserializer<StoredUser, User>(fn: DeserializeFunction<StoredUser, User>) {
     this.deserializers.push(fn)
   }
 


### PR DESCRIPTION
The types for `registerUserDeserializer` were swapped and inconsistent with `registerUserSerializer`.

#### Checklist

- [ ] run `npm run test` and `npm run benchmark`
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [ ] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
