### PR TITLE
support keeping session info during session regenerate on req.login

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,9 +82,9 @@ fastifyPassport.use('test', new SomePassportStrategy()) // you'd probably use so
 ## Session cleanup on logIn
 
 For security reasons the session is cleaned after login. You can manage this configuration at your own risk by:
-1) Include `keepSessionInfo` true option when perform the passport `.authenticate` call.
-2) Include `keepSessionInfo` true option when perform the request `.login` call.
-3) using `clearSessionOnLogin (default: true)` and `clearSessionIgnoreFields (default: ['passport', 'session'])`
+1) Include `keepSessionInfo` true option when perform the passport `.authenticate` call;
+2) Include `keepSessionInfo` true option when perform the request `.login` call;
+3) Using `clearSessionOnLogin (default: true)` and `clearSessionIgnoreFields (default: ['passport', 'session'])`.
 
 ## Difference between `@fastify/secure-session` and `@fastify/session`
 `@fastify/secure-session` and `@fastify/session` are both session plugins for Fastify which are capable of encrypting/decrypting the session. The main difference is that `@fastify/secure-session` uses the stateless approach and stores the whole session in an encrypted cookie whereas `@fastify/session` uses the stateful approach for sessions and stores them in a session store.
@@ -138,7 +138,7 @@ Options:
   message for failures (overrides any from the strategy itself).
 - `assignProperty` Assign the object provided by the verify callback to given property
 - `state` Pass any provided state through to the strategy (e.g. for Google Oauth)
-  - `keepSessionInfo` True to save existing session properties after authentication
+- `keepSessionInfo` True to save existing session properties after authentication
 
 An optional `callback` can be supplied to allow the application to override the default manner in which authentication attempts are handled. The callback has the following signature:
 

--- a/README.md
+++ b/README.md
@@ -81,8 +81,10 @@ fastifyPassport.use('test', new SomePassportStrategy()) // you'd probably use so
 
 ## Session cleanup on logIn
 
-For security reasons the session is cleaned after login. You can manage this configuration at your own risk by using
-`clearSessionOnLogin (default: true)` and `clearSessionIgnoreFields (default: ['passport', 'session'])`
+For security reasons the session is cleaned after login. You can manage this configuration at your own risk by:
+1) Include `keepSessionInfo` true option when perform the passport `.authenticate` call.
+2) Include `keepSessionInfo` true option when perform the request `.login` call.
+3) using `clearSessionOnLogin (default: true)` and `clearSessionIgnoreFields (default: ['passport', 'session'])`
 
 ## Difference between `@fastify/secure-session` and `@fastify/session`
 `@fastify/secure-session` and `@fastify/session` are both session plugins for Fastify which are capable of encrypting/decrypting the session. The main difference is that `@fastify/secure-session` uses the stateless approach and stores the whole session in an encrypted cookie whereas `@fastify/session` uses the stateful approach for sessions and stores them in a session store.
@@ -136,6 +138,7 @@ Options:
   message for failures (overrides any from the strategy itself).
 - `assignProperty` Assign the object provided by the verify callback to given property
 - `state` Pass any provided state through to the strategy (e.g. for Google Oauth)
+  - `keepSessionInfo` True to save existing session properties after authentication
 
 An optional `callback` can be supplied to allow the application to override the default manner in which authentication attempts are handled. The callback has the following signature:
 

--- a/src/AuthenticationRoute.ts
+++ b/src/AuthenticationRoute.ts
@@ -34,6 +34,7 @@ export interface AuthenticateOptions {
   authInfo?: boolean
   session?: boolean
   pauseStream?: boolean
+  keepSessionInfo?: boolean
 }
 
 export type SingleStrategyCallback = (

--- a/src/decorators/login.ts
+++ b/src/decorators/login.ts
@@ -22,8 +22,16 @@ export type DoneCallback = (err?: Error) => void
  * @api public
  */
 export async function logIn<T = unknown>(this: FastifyRequest, user: T): Promise<void>
-export async function logIn<T = unknown>(this: FastifyRequest, user: T, options: { session?: boolean }): Promise<void>
-export async function logIn<T = unknown>(this: FastifyRequest, user: T, options: { session?: boolean } = {}) {
+export async function logIn<T = unknown>(
+  this: FastifyRequest,
+  user: T,
+  options: { session?: boolean; keepSessionInfo?: boolean }
+): Promise<void>
+export async function logIn<T = unknown>(
+  this: FastifyRequest,
+  user: T,
+  options: { session?: boolean; keepSessionInfo?: boolean } = {}
+) {
   if (!this.passport) {
     throw new Error('passport.initialize() plugin not in use')
   }
@@ -34,7 +42,7 @@ export async function logIn<T = unknown>(this: FastifyRequest, user: T, options:
   this[property] = user
   if (session) {
     try {
-      await this.passport.sessionManager.logIn(this, user)
+      await this.passport.sessionManager.logIn(this, user, options)
     } catch (e) {
       this[property] = null
       throw e

--- a/src/session-managers/SecureSessionManager.ts
+++ b/src/session-managers/SecureSessionManager.ts
@@ -42,7 +42,7 @@ export class SecureSessionManager {
       if (this.clearSessionOnLogin && object) {
         const keepSessionInfoKeys: string[] = [...this.clearSessionIgnoreFields]
         if (options?.keepSessionInfo) {
-          keepSessionInfoKeys.push(...(Object.keys(request.session) || []))
+          keepSessionInfoKeys.push(...(Object.keys(request.session)))
         }
         await request.session.regenerate(keepSessionInfoKeys)
       } else {

--- a/src/session-managers/SecureSessionManager.ts
+++ b/src/session-managers/SecureSessionManager.ts
@@ -42,7 +42,7 @@ export class SecureSessionManager {
       if (this.clearSessionOnLogin && object) {
         const keepSessionInfoKeys: string[] = [...this.clearSessionIgnoreFields]
         if (options?.keepSessionInfo) {
-          keepSessionInfoKeys.push(...(Object.keys(request.session)))
+          keepSessionInfoKeys.push(...Object.keys(request.session))
         }
         await request.session.regenerate(keepSessionInfoKeys)
       } else {

--- a/src/session-managers/SecureSessionManager.ts
+++ b/src/session-managers/SecureSessionManager.ts
@@ -1,5 +1,6 @@
 /// <reference types="@fastify/secure-session" />
 import { FastifyRequest } from 'fastify'
+import { AuthenticateOptions } from '../AuthenticationRoute'
 import { SerializeFunction } from '../Authenticator'
 
 /** Class for storing passport data in the session using `@fastify/secure-session` or `@fastify/session` */
@@ -33,13 +34,17 @@ export class SecureSessionManager {
     }
   }
 
-  async logIn(request: FastifyRequest, user: any) {
+  async logIn(request: FastifyRequest, user: any, options?: AuthenticateOptions) {
     const object = await this.serializeUser(user, request)
 
     // Handle @fastify/session to prevent token/CSRF fixation
     if (request.session.regenerate) {
       if (this.clearSessionOnLogin && object) {
-        await request.session.regenerate(this.clearSessionIgnoreFields)
+        let keepSessionInfoKeys: string[] = [...this.clearSessionIgnoreFields]
+        if (options?.keepSessionInfo) {
+          keepSessionInfoKeys.push(...(Object.keys(request.session) || []))
+        }
+        await request.session.regenerate(keepSessionInfoKeys)
       } else {
         await request.session.regenerate()
       }
@@ -50,7 +55,7 @@ export class SecureSessionManager {
     else if (this.clearSessionOnLogin && object) {
       const currentFields = request.session.data() || {}
       for (const field of Object.keys(currentFields)) {
-        if (this.clearSessionIgnoreFields.includes(field)) {
+        if (options?.keepSessionInfo || this.clearSessionIgnoreFields.includes(field)) {
           continue
         }
         request.session.set(field, undefined)

--- a/src/session-managers/SecureSessionManager.ts
+++ b/src/session-managers/SecureSessionManager.ts
@@ -40,7 +40,7 @@ export class SecureSessionManager {
     // Handle @fastify/session to prevent token/CSRF fixation
     if (request.session.regenerate) {
       if (this.clearSessionOnLogin && object) {
-        let keepSessionInfoKeys: string[] = [...this.clearSessionIgnoreFields]
+        const keepSessionInfoKeys: string[] = [...this.clearSessionIgnoreFields]
         if (options?.keepSessionInfo) {
           keepSessionInfoKeys.push(...(Object.keys(request.session) || []))
         }

--- a/test/secure-session-manager.test.ts
+++ b/test/secure-session-manager.test.ts
@@ -107,6 +107,6 @@ describe('SecureSessionManager', () => {
     } as unknown as FastifyRequest
     await sessionManger.logIn(request, user, { keepSessionInfo: false })
     expect(request.session.set).toHaveBeenCalledTimes(1)
-    expect(request.session.set).toHaveBeenCalledWith('passport', { 'id': 'test' })
+    expect(request.session.set).toHaveBeenCalledWith('passport', { id: 'test' })
   })
 })

--- a/test/secure-session-manager.test.ts
+++ b/test/secure-session-manager.test.ts
@@ -67,4 +67,46 @@ describe('SecureSessionManager', () => {
     await sessionManger.logIn(request, user)
     expect(request.session.regenerate).toHaveBeenCalledTimes(1)
   })
+
+  test('should call request.session.regenerate function with all properties from session if keepSessionInfo is true', async () => {
+    const sessionManger = new SecureSessionManager(
+      { clearSessionOnLogin: true },
+      ((id) => id) as unknown as SerializeFunction
+    )
+    const user = { id: 'test' }
+    const request = {
+      session: { regenerate: jest.fn(() => {}), set: () => {}, data: () => {}, sessionValue: 'exist' }
+    } as unknown as FastifyRequest
+    await sessionManger.logIn(request, user, { keepSessionInfo: true })
+    expect(request.session.regenerate).toHaveBeenCalledTimes(1)
+    expect(request.session.regenerate).toHaveBeenCalledWith(['session', 'regenerate', 'set', 'data', 'sessionValue'])
+  })
+
+  test('should call request.session.regenerate function with default properties from session if keepSessionInfo is false', async () => {
+    const sessionManger = new SecureSessionManager(
+      { clearSessionOnLogin: true },
+      ((id) => id) as unknown as SerializeFunction
+    )
+    const user = { id: 'test' }
+    const request = {
+      session: { regenerate: jest.fn(() => {}), set: () => {}, data: () => {}, sessionValue: 'exist' }
+    } as unknown as FastifyRequest
+    await sessionManger.logIn(request, user, { keepSessionInfo: false })
+    expect(request.session.regenerate).toHaveBeenCalledTimes(1)
+    expect(request.session.regenerate).toHaveBeenCalledWith(['session'])
+  })
+
+  test('should call session.set function if no regenerate function provided and keepSessionInfo is true', async () => {
+    const sessionManger = new SecureSessionManager(
+      { clearSessionOnLogin: true },
+      ((id) => id) as unknown as SerializeFunction
+    )
+    const user = { id: 'test' }
+    const request = {
+      session: { set: jest.fn(), data: () => {}, sessionValue: 'exist' }
+    } as unknown as FastifyRequest
+    await sessionManger.logIn(request, user, { keepSessionInfo: false })
+    expect(request.session.set).toHaveBeenCalledTimes(1)
+    expect(request.session.set).toHaveBeenCalledWith('passport', { 'id': 'test' })
+  })
 })


### PR DESCRIPTION
#### Issue

https://github.com/fastify/fastify-passport/issues/1141

#### What's changed

Request login method started to accept `keepSessionInfo` boolean parameter. In a moment when we are going to perform cleanup session info, with specified keepSessionInfo=true param, we prevent clearing session on login. 

See the description of the same functionality on original passport project: https://medium.com/passportjs/fixing-session-fixation-b2b68619c51d 

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [ ] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
