### PR TITLE
docs(readme): update ci badge syntax

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # @fastify/passport
 
-[![CI](https://github.com/fastify/fastify-passport/workflows/CI/badge.svg)](https://github.com/fastify/fastify-passport/actions/workflows/ci.yml)
+[[![CI](https://github.com/fastify/fastify-passport/actions/workflows/ci.yml/badge.svg?branch=main)](https://github.com/fastify/fastify-passport/actions/workflows/ci.yml)](https://github.com/fastify/fastify-passport/actions/workflows/ci.yml)
 [![NPM version](https://img.shields.io/npm/v/@fastify/passport.svg?style=flat)](https://www.npmjs.com/package/@fastify/passport)
 [![code style: prettier](https://img.shields.io/badge/code_style-prettier-ff69b4.svg?style=flat)](https://github.com/prettier/prettier)
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # @fastify/passport
 
-[[![CI](https://github.com/fastify/fastify-passport/actions/workflows/ci.yml/badge.svg?branch=main)](https://github.com/fastify/fastify-passport/actions/workflows/ci.yml)](https://github.com/fastify/fastify-passport/actions/workflows/ci.yml)
+[![CI](https://github.com/fastify/fastify-passport/actions/workflows/ci.yml/badge.svg?branch=main)](https://github.com/fastify/fastify-passport/actions/workflows/ci.yml)
 [![NPM version](https://img.shields.io/npm/v/@fastify/passport.svg?style=flat)](https://www.npmjs.com/package/@fastify/passport)
 [![code style: prettier](https://img.shields.io/badge/code_style-prettier-ff69b4.svg?style=flat)](https://github.com/prettier/prettier)
 


### PR DESCRIPTION
Syntax has changed, see https://docs.github.com/en/actions/monitoring-and-troubleshooting-workflows/monitoring-workflows/adding-a-workflow-status-badge