### PR TITLE
perf: use `node:` prefix to bypass require.cache call for builtins

### DIFF
--- a/src/AuthenticationRoute.ts
+++ b/src/AuthenticationRoute.ts
@@ -1,9 +1,9 @@
-import * as http from 'http'
+import * as http from 'node:http'
 import AuthenticationError from './errors'
 import Authenticator from './Authenticator'
 import { AnyStrategy, Strategy } from './strategies'
 import { FastifyReply, FastifyRequest } from 'fastify'
-import { types } from 'util'
+import { types } from 'node:util'
 
 type FlashObject = { type?: string; message?: string }
 type FailureObject = {

--- a/test/passport.test.ts
+++ b/test/passport.test.ts
@@ -2,7 +2,7 @@
 import { test, describe } from 'node:test'
 import assert from 'node:assert'
 import got from 'got'
-import { AddressInfo } from 'net'
+import { AddressInfo } from 'node:net'
 import { AuthenticateOptions } from '../src/AuthenticationRoute'
 import Authenticator from '../src/Authenticator'
 import { Strategy } from '../src/strategies'


### PR DESCRIPTION
See https://github.com/fastify/fastify-static/pull/407. This is a batch PR, so may have some issues. Please review changes.