### PR TITLE
feat: implement programmatic auth API

### DIFF
--- a/AI.md
+++ b/AI.md
@@ -1,0 +1,23 @@
+# AI Use
+
+Throughout this assignment I collaborated with an AI assistant to develop faster, improve my design, and develop a robust testing suite
+
+## How AI Was Used
+
+### 1. Codebase Exploration & Analysis
+I have not worked with Fastify or Passport before. The AI tools were very useful to help me understand what both repos were doing and why fastify-passport needed to exist. I learned that Passport was created years ago to work alongside Express using a callback based architecture. And although Express less  today, Passport continues to thrive with new frameworks like Fastify that use a more modern promise based architecture. Fastify-passport exists to bridge that gap from legacy Express architecture to modern fastify.
+
+### 2. Architectural Brainstorming
+I discussed various directions we could take the project with the AI tool. I honestly probably spent most of my time going back and forth with the AI in the types.ts file before writing any execution logic. It was incredibly helpful to bounce ideas off of and to lookup certain properties or conventions already existed in the legacy Passport code so we could reuse them or stay consistent. Once I was confident with the types.ts the rest of the application was easier and fit together nicely.
+
+### 3. AI as a reviewer
+As development went, I used a second AI to review the code to catch any edge cases that I may have missed in my own review
+- **Object.assign vs Object.create:** The original implementation used Object.assign on review by the AI reviewer it caught that this was going to cause errors. We then wrote a test to confirm and found that it was true. It's something that we would've caught anyway in testing but it's great to catch that as soon as possible.
+- **Timing Accuracy:** The AI pointed out that we should use `performance.now()` instead of `Date.now()` for more accurate metrics on performance.
+- **Empty strategy array:** The AI reviewer found that even if the stragey array was empty we passed the array along which would confusinly return empty data. We cleaned that up by returning early and giving a more explicit message that the array was empty.
+
+### 4. Test Generation & Validation
+I used the AI to help write the unit tests. It was great at identifying edge cases and it helped make an extremly robust testing suite. The AI reviewer even pointed out that one of the tests didn't accurately test that `AuthContext` wasn't being shared across requests. Before the two requests were run together but since they return immdiately there really wasn't any time for the 2nd request to overwrite the firsts context. It gave the good advice to have the first one wait a little bit for the 2nd one to finish and then check if the 1st requests `AuthContext` was corrupted by the 2nds or if it is what we expected it to be.
+
+### 5. What I didn't use AI for (mostly)
+I didn't use AI for this file or the DESIGN.md. In a real setting I would probably use AI to speed up drafting a design or requirements doc before reviewing and editting it. But since this project was to go over my competency I thought it was important that all of this was my own words. I used AI to check my grammar and help with some of the flow but for the most part this came from me.

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -1,0 +1,67 @@
+# Fastify-Passport Programmatic API Design
+
+This document outlines my thought process through important decisions that were made while
+implementing the `authenticateRequest` function that provides a programmatic auth API for
+`@fastify/passport`
+
+## 1. Implementation Architecture
+
+**Promise-based Flow**
+Passport code is callback-based but we want it to be Promise-based. Passport strategies work by executing and then calling one of five callbacks (`success`, `fail`, `error`, `redirect`, `pass`) when the execution is done. To change this to be a promise based flow we make a clone of the strategy and patch the callback methods to resolve or reject a promise. So `strategy.authenticate(request, options)` will run the same exact strategy code as before but return a promise instead of using callbacks.
+
+**How we clone matters**
+At first I considered the classic cloning method of using `Object.assign` to clone the strategy but after some research I realized this would break the prototype chain. This would cause issues where the strategy would lose it's parent class methods. This would break the strategy's ability to call `this.success()`, `this.fail()`, etc. I found that `Object.create(strategy)` would create a new object that kept the prototype chain intact.
+
+**Stateless Method vs. Stateful Class**
+I considered following the originals codes design of the `Authenticator` class calling another class to handle the execution logic. After looking deeper into how the original code worked, I realized that `AuthenticatorRoute` is a factory that needed to be stateful to to hold the data for the route hook function. Our new method is just a function that executes statelessly. It seemed overkill to create a new class even if thats what the original code did. So I decided to just keep the code in `Authenticator.ts`
+
+**Duplication of logic over helper functions**
+I noticed the `getStrategyName` and `getStrategy` in the `AuthenticatorRoute` was code that could be used for our new logic too. I considered moving it to a shared utility file to avoid duplicating code, but realized that since `AuthenticatorRoute` was a separate class, it had to call the public `this.authenticator.strategy()` method to get the strategy. And since our code was already in `Authenticator.ts`, we had access to the `this.strategies` variable directly. A helper would have to pass around `this.strategies` or the `Authenticator` class to the helper function which felt messy and some duplicate code was better than a confusing abstraction. That's how we ended up with `resolveStrategyName` and `resolveStrategy` in `Authenticator.ts`.
+
+## 2. API Design Decisions
+
+**Naming Conventions in Types.ts**
+The most common question I had when making the types was how does the current Passport code and `Authenticator` class handle the types. If we needed data and it already was called something else in the Passport code (like challenge, status, or info), we just used that name. If we needed data and it didn't exist in the Passport code, we tried to keep to same naming convention of other types
+
+**AuthResult**
+The assignment gives a pretty comprehensive example of what `AuthResult` should look like. Here's my reaosoning for some of my departures from the example:
+**Strategy is optional**
+I didn't want to return a strategy if all strategies failed. So I made it optional, the developer would have to check if `ok` is true before using the strategy. But I think this is better than returning a strategy that could've failed.
+
+**Staus code NOT optional**
+It's a little redundant to return a 200 when `ok` it true but I think the consistency of always having a status code is worth the redundancy. I realize this seems to contradict my `Strategy is optional` decision but I think the difference is that status code always does exist, it's just a decision to give it to the developer or not. Whereas `strategy` can be misleading if returned when all strategies failed.
+
+**RedirectUrl**
+Passport right now automatically set a header when the `redirect` callback fires. We want to keep that behavior possible but hand the final decision to the developer on what to ultimately do. So instead of setting the header we return a `redirectUrl` property. The developer can then use that data to redirect the user or whatever else they want to do.
+
+**Info unknown**
+I wasn't sure what `info` was at first and wondered if it could be typed. But `info` is defined by the strategy and there's no standard so we truly don't know what it is.
+
+**AuthContext**
+Again the assignment gives a good example of what `AuthContext` should look like and I'll share the decisions I made to change it and why.
+
+**Change attempts to an object**
+AuthContext is an object to store the overall outcome of the authentication attempt. I used the attempts field on it to store data on each individual strategy attempt. We stored the strategy name, outcome, elapsed time and error type. One concern I have is if its harder for metrics to read the length of an array compared to just a number. I decided that modern metrics tools are able to determine a length of an array so I decided it was fine to replace the attempts amounts number.
+
+**successfulStrategy**
+Same as `strategy` in `AuthResult` I thought optional would be good to only appear on success for the same reasons. I renamed it to `successfulStrategy` though to be more clear since the `AuthAttempt` type also has a `strategy` field. And the top level `successfulStrategy` field is for the whole authentication attempt.
+
+**API Design**
+Most of the design decisions were based on giving the developer to power to control the flow of the authentication process. Here's some of the more niche decisions I made.
+**`authenticateRequest()` does NOT auto-login (but it can)**
+The assignment says `implicit side effects only`. Passport has a `AuthenticateOptions` with a `session` option that defaults to `true` and auto logs the user in on a successful authenticate so we want to turn that off. But a developer might want an easy way to auto login, Passports `AuthenticateOptions` has a `session` option. So instead of calling `authContext.login(user)` after a successful authentication, the developer can just pass `session: true` to `authenticateRequest` and it will auto login the user.
+
+**`error()` halts the loop**
+I considered allowing `error()` try the next strategy. I thought it might be good to try another strategy if one strategy was temporarily down or something. But I noticed that the original code stop's the execution on any error. This made me think of the unexpected behaviours that could emerge if we continued the loop on an error. Like an example is if we used our database to blacklist a user and the database was down, if we skipped over the error and tried another the malicious user could still login. So ultimately I decided to just do what Passport was doing.
+
+## 3. Security & Observability
+
+**Sanitized Errors**
+The errors returned from strategies can be anything the strategies want to throw. So we can't really trust the payload. A database could error with raw SQL or an OAUTH provider could throw a token. To hopefully give the developer some context without risking leaking important infrastructure secrets or PII I decided to return the `error.name` of the error thrown. It should give some context like `TokenExpiredError` or `InvalidTokenError` but not the full error message. We could maybe use regex to redact PII from the error message but I think it's not worth it for being computaionally expensive and having too much risking of letting PII slip through the filters.
+
+**User ID PII Tradeoff**
+With our implementation `userId` could have PII in it. If the application developer uses something like an `email` as the user id then we're logging that email here. I considered not logging it but I think at some point we have to offload the responsibility to the application developer to not use PII as the user id. Maybe this is a mistake but I think the `userId` is too valuable of context to not log it for some applications. Hopefully no one is using SSN's as userIds!
+
+## 4. Bonus, Edge Cases, Known Limitations
+**Hanging Promise**
+I didn't get to this but I'll explain the timeout problem and how we would solve it. Just like Passport itself, we are using strategies that aren't designed and written by us. If a strategy is poorly written and never calls any of the functions that resolve the promise then we will hang indefinitely. We would handle this is add a timeout that rejects the promise if it takes too long. This should work the same way as if the strategy called `error()` since it opens us to the same security risks if we contiue

--- a/README.md
+++ b/README.md
@@ -16,6 +16,36 @@ Beta. `@fastify/passport` is still a relatively new project. There may be incomp
 npm i @fastify/passport
 ```
 
+## Running the Demo
+
+This repository includes a fully-functional Demo Server (`demo-auth-server.ts`) that showcases exactly how to use the programmatic `authenticateRequest()` API and `request.authContext` observability hook. The demo utilizes two mocked strategies: stateful `Session` and stateless `API Key` fallback.
+
+To test the demo server locally:
+
+**1. Start the server (Requires ts-node):**
+```bash
+npm run build
+npx ts-node demo-auth-server.ts
+```
+
+**2. Test the endpoints:**
+You can test the programmatic auth fallback logic using the following curl commands. The protected route will attempt to authenticate via the stateful Session cookie first, and if that fails, it will attempt to authenticate statelessly via the `x-api-key` header.
+
+```bash
+# Login (creates a secure session)
+curl http://127.0.0.1:3000/login
+
+# Test Protected Route (fails if no session/key is present)
+# Succeeds statelessly with API key header
+curl -H "x-api-key: secret-key" http://127.0.0.1:3000/protected
+
+# Test with an invalid API key header
+curl -H "x-api-key: invalid" http://127.0.0.1:3000/protected
+
+# Logout (clears session and forces fallback to API key on next request)
+curl http://127.0.0.1:3000/logout
+```
+
 ## Google OAuth2 Video tutorial
 
 The community created this fast introduction to `@fastify/passport`:
@@ -231,6 +261,37 @@ fastify.get(
 )
 ```
 
+### authenticateRequest(strategy: string | Strategy | (string | Strategy)[], request: FastifyRequest, reply: FastifyReply, options?: AuthenticateOptions)
+
+A programmatic alternative to `.authenticate()`. Returns a `Promise<AuthResult>` instead of a Fastify route hook, allowing you to explicitly handle the authentication result and control the response flow inside your route handler.
+
+The `AuthResult` object contains the outcome of the authentication attempt, including `ok: boolean`, the `statusCode` (e.g. 200, 401), and the authenticated `user` (if successful). If authentication fails across all strategies, it may contain `challenges` from the attempted strategies.
+
+Options:
+- `session` Save login state in session, defaults to _false_ (different from `.authenticate()`)
+- Other options like `assignProperty`, `state`, and `keepSessionInfo` are also supported. Note that redirection options (`successRedirect`, `failureRedirect`) will not automatically trigger a redirect; instead, their URLs will be returned in the `AuthResult.redirectUrl` property for you to handle manually.
+
+Example:
+
+```js
+fastify.get('/protected', async (request, reply) => {
+  const result = await fastifyPassport.authenticateRequest(['bearer', 'basic'], request, reply)
+
+  if (result.ok) {
+    return reply.code(200).send({
+      message: 'Authentication successful!',
+      user: result.user
+    })
+  } else {
+    // result.statusCode will typically be 401
+    return reply.code(result.statusCode).send({
+      error: 'Authentication failed',
+      challenges: result.challenges
+    })
+  }
+})
+```
+
 ### authorize(strategy: string | Strategy | (string | Strategy)[], options: AuthenticateOptions = {}, callback?: AuthenticateCallback)
 
 Returns a hook that will authorize a third-party account using the given `strategy`, with optional `options`. Intended for use as a `preValidation` hook on any route. `.authorize` has the same API as `.authenticate`, but has one key difference: it doesn't modify the logged in user's details. Instead, if authorization is successful, the result provided by the strategy's verify callback will be assigned to `request.account`. The existing login session and `request.user` will be unaffected.
@@ -324,6 +385,19 @@ Therefore, a deserializer can return several things:
 ### Request#isUnauthenticated()
 
 Test if request is unauthenticated.
+
+### Request#authContext
+
+During an authentication attempt (either via `.authenticate()` hook or `.authenticateRequest()`), `@fastify/passport` exposes `request.authContext` to provide deep observability into the authentication process. This object is populated incrementally as strategies execute and provides a summary upon completion.
+
+The context includes:
+- `outcome`: The final result (`'authenticated'`, `'rejected'`, `'error'`, etc.)
+- `successfulStrategy`: The name of the strategy that eventually succeeded (if any)
+- `elapsedMs`: Total time spent authenticating across all strategies
+- `userId`: The `id` property from the authenticated user object, if present
+- `attempts`: An array detailing the `strategy` name, `outcome`, `elapsedMs`, and specific `errorType` (if applicable) for each individual strategy tried
+
+This is highly useful for audit logging, metrics aggregation, and debugging complex multi-strategy scenarios.
 
 ## Using with TypeScript
 

--- a/demo-auth-server.ts
+++ b/demo-auth-server.ts
@@ -1,0 +1,107 @@
+import fastify, { FastifyRequest } from 'fastify'
+import fastifyPassport from './src/index'
+import { Strategy } from './src/strategies'
+import fastifySecureSession from '@fastify/secure-session'
+
+const server = fastify({ logger: true })
+
+// 1. Setup Session plugins (required by passport core)
+server.register(fastifySecureSession, {
+    key: Buffer.alloc(32, 'a'),
+    cookie: { path: '/' }
+})
+server.register(fastifyPassport.initialize())
+// (Commented out because this adds a global block that intercepts requests before they reach our programmatic handler)
+// server.register(fastifyPassport.secureSession())
+
+// 2. Define our Mock Strategies
+
+// A mock API Key strategy that only accepts "secret-key"
+class ApiKeyStrategy extends Strategy {
+    name = 'api-key'
+    authenticate(request: FastifyRequest) {
+        const key = request.headers['x-api-key']
+        if (key === 'secret-key') {
+            return this.success({ id: 'user-123', name: 'API User' })
+        }
+        this.fail('ApiKey', 401)
+    }
+}
+
+// A mock Session strategy that checks if a session exists
+class MockSessionStrategy extends Strategy {
+    name = 'session'
+    authenticate(request: FastifyRequest) {
+        // In a real app, this would verify and deserialize the secure session cookie
+        if (request.session && request.session.get('passport')) {
+            return this.success({ id: 'session-user', name: 'Session User' })
+        }
+        // If no session exists, fail so it falls back to the next strategy
+        this.fail('Session', 401)
+    }
+}
+
+// 3. Register the strategies
+fastifyPassport.use('api-key', new ApiKeyStrategy('api-key'))
+fastifyPassport.use('session', new MockSessionStrategy('session'))
+
+// 4. Create the Demo Routes using the new programmatic API
+
+server.get('/public', (request, reply) => {
+    reply.send({ message: 'This is a public route.' })
+})
+
+server.get('/login', (request, reply) => {
+    // In a real app this would be checking user credentials
+    // For the demo we just blindly set the session cookie
+    request.session.set('passport', { user: 'u1' })
+    reply.send({ message: 'Logged in! A secure session cookie has been set.' })
+})
+
+server.get('/logout', (request, reply) => {
+    request.session.delete()
+    reply.send({ message: 'Logged out! Session cookie cleared.' })
+})
+
+server.get('/protected', async (request, reply) => {
+    // Using the new programmatic API!
+    // Try session first, fall back to API key
+    const result = await fastifyPassport.authenticateRequest(
+        ['session', 'api-key'],
+        request,
+        reply
+    )
+
+    if (result.ok) {
+        // Authenticated! We control the response.
+        return reply.code(200).send({
+            message: 'Authentication successful!',
+            authenticatedBy: result.strategy,
+            user: result.user,
+            context: request.authContext
+        })
+    } else {
+        // Failed! We control the response formatting.
+        return reply.code(result.statusCode!).send({
+            error: 'Authentication failed',
+            challenges: result.challenges, // Returns ['Session', 'ApiKey']
+            context: request.authContext
+        })
+    }
+})
+
+// 5. Start the server
+server.listen({ port: 3000 }, (err, address) => {
+    if (err) {
+        server.log.error(err)
+        process.exit(1)
+    }
+    console.log(`\n🚀 Demo server listening at ${address}`)
+    console.log('\n--- Test Endpoints ---')
+    console.log('Test programmatic auth fallback on the /protected route.')
+    console.log('The route will try the [Session] strategy first, and fall back to [API Key].\n')
+    console.log(`  Login (creates session):   curl ${address}/login`)
+    console.log(`  Protected (valid key):     curl -H "x-api-key: secret-key" ${address}/protected`)
+    console.log(`  Protected (invalid key):   curl -H "x-api-key: invalid" ${address}/protected`)
+    console.log(`  Logout (clears session):   curl ${address}/logout\n`)
+})

--- a/package-lock.json
+++ b/package-lock.json
@@ -1271,6 +1271,7 @@
       "integrity": "sha512-TGf22kon8KW+DeKaUmOibKWktRY8b2NSAZNdtWh798COm1NWx8+xJ6iFBtk3IvLdv6+LGLJLRlyhrhEDZWargQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.45.0",
         "@typescript-eslint/types": "8.45.0",
@@ -1750,6 +1751,7 @@
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.15.0.tgz",
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "dev": true,
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -3366,6 +3368,7 @@
       "integrity": "sha512-vPZZsiOKaBAIATpFE2uMI4w5IRwdv/FpQ+qZZMR4E+PeOcM4OeoEbqxRMnywdxP19TyB/3h6QBB0EWon7letSQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@typescript-eslint/types": "^8.35.0",
         "comment-parser": "^1.4.1",
@@ -7134,6 +7137,7 @@
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },

--- a/src/Authenticator.ts
+++ b/src/Authenticator.ts
@@ -1,11 +1,15 @@
-import type { FastifyPluginAsync, FastifyRequest, RouteHandlerMethod } from 'fastify'
+import type { FastifyPluginAsync, FastifyReply, FastifyRequest, PassportUser, RouteHandlerMethod } from 'fastify'
 import { fastifyPlugin } from 'fastify-plugin'
+import { types } from 'node:util'
 import { type AuthenticateCallback, type AuthenticateOptions, AuthenticationRoute } from './AuthenticationRoute'
 import { CreateInitializePlugin } from './CreateInitializePlugin'
 import { SecureSessionManager } from './session-managers/SecureSessionManager'
 import type { AnyStrategy } from './strategies/index'
 import type { Strategy } from './strategies/base'
 import { SessionStrategy } from './strategies/SessionStrategy'
+import { type AuthResult, type AuthContext, type AuthAttempt } from './types'
+
+const Unhandled = Symbol.for('passport-unhandled')
 
 export type SerializeFunction<User = any, SerializedUser = any> = (
   user: User,
@@ -40,7 +44,7 @@ export class Authenticator {
   private clearSessionOnLogin: boolean
   private clearSessionIgnoreFields: string[]
 
-  constructor (options: AuthenticatorOptions = {}) {
+  constructor(options: AuthenticatorOptions = {}) {
     this.key = options.key || 'passport'
     this.userProperty = options.userProperty || 'user'
     this.use(new SessionStrategy(this.deserializeUser.bind(this)))
@@ -56,9 +60,9 @@ export class Authenticator {
     )
   }
 
-  use (strategy: AnyStrategy): this
-  use (name: string, strategy: AnyStrategy): this
-  use (name: AnyStrategy | string, strategy?: AnyStrategy): this {
+  use(strategy: AnyStrategy): this
+  use(name: string, strategy: AnyStrategy): this
+  use(name: AnyStrategy | string, strategy?: AnyStrategy): this {
     if (!strategy) {
       strategy = name as AnyStrategy
       name = strategy.name as string
@@ -71,12 +75,12 @@ export class Authenticator {
     return this
   }
 
-  public unuse (name: string): this {
+  public unuse(name: string): this {
     delete this.strategies[name]
     return this
   }
 
-  public initialize (): FastifyPluginAsync {
+  public initialize(): FastifyPluginAsync {
     return CreateInitializePlugin(this)
   }
 
@@ -175,6 +179,254 @@ export class Authenticator {
   }
 
   /**
+   * Programmatically authenticate a request inside a route handler.
+   *
+   * Unlike `authenticate()`, which returns a hook/handler, this method takes
+   * a live `request` and `reply` and returns a Promise<AuthResult> with the
+   * outcome. It does NOT automatically send a response or log the user in
+   * (unless `options.session` is set to `true`).
+   *
+   * When an array of strategies is given, they are tried in order.
+   * The first strategy to succeed wins. Failures fall through to the next.
+   * If all strategies fail, the result will be `{ ok: false }` with
+   * aggregate challenge and status information.
+   *
+   * @param strategyOrStrategies - Strategy name(s) or instance(s) to attempt
+   * @param request - The current Fastify request
+   * @param reply - The current Fastify reply
+   * @param options - Optional authentication options
+   * @returns A Promise that resolves with the authentication result
+   *
+   * @example
+   * ```typescript
+   * const result = await fastifyPassport.authenticateRequest('api-key', request, reply)
+   * if (result.ok) {
+   *   reply.send({ user: result.user })
+   * } else {
+   *   reply.code(result.statusCode).send({ error: 'Authentication failed' })
+   * }
+   * ```
+   */
+  public async authenticateRequest(
+    strategyOrStrategies: string | Strategy | (string | Strategy)[],
+    request: FastifyRequest,
+    reply: FastifyReply,
+    options?: AuthenticateOptions
+  ): Promise<AuthResult> {
+    if (!request.passport) {
+      throw new Error('passport.initialize() plugin not in use')
+    }
+
+    const opts = options || {}
+    const strategies: (string | Strategy)[] = Array.isArray(strategyOrStrategies)
+      ? strategyOrStrategies
+      : [strategyOrStrategies]
+
+    if (strategies.length === 0) {
+      throw new Error('authenticateRequest requires at least one strategy')
+    }
+
+    const startTime = performance.now()
+    const failures: { challenge?: string; status?: number }[] = []
+    const attemptDetails: AuthAttempt[] = []
+
+    for (const nameOrInstance of strategies) {
+      const name = this.resolveStrategyName(nameOrInstance)
+      const baseStrategy = this.resolveStrategy(nameOrInstance)
+      const attemptStart = performance.now()
+
+      try {
+        const result = await this.attemptStrategyProgrammatic(name, baseStrategy, request, reply, opts, failures)
+
+        // Record this attempt
+        const attemptOutcome = result.ok
+          ? 'success'
+          : result.redirectUrl
+            ? 'redirect'
+            : 'pass'
+        attemptDetails.push({
+          strategy: name,
+          outcome: attemptOutcome,
+          elapsedMs: performance.now() - attemptStart
+        })
+
+        // Auto-login to session if options.session is true
+        if (result.ok && opts.session) {
+          await request.logIn(result.user!, opts)
+        }
+
+        // Populate authContext
+        this.setAuthContext(request, {
+          successfulStrategy: result.ok ? result.strategy : undefined,
+          elapsedMs: performance.now() - startTime,
+          outcome: result.ok ? 'authenticated' : 'rejected',
+          userId: result.ok && result.user ? String((result.user as any).id ?? '') : undefined,
+          attempts: attemptDetails
+        })
+
+        return result
+      } catch (e) {
+        if (e === Unhandled) {
+          // fail() — wrong credentials, try next strategy
+          attemptDetails.push({ strategy: name, outcome: 'fail', elapsedMs: performance.now() - attemptStart })
+          continue
+        }
+        if (e instanceof Error) {
+          // error() — infrastructure failure, halt the loop (consistent with existing Passport behavior)
+          const errorName = e.name || 'Error'
+          attemptDetails.push({ strategy: name, outcome: 'error', elapsedMs: performance.now() - attemptStart, errorType: errorName })
+
+          this.setAuthContext(request, {
+            elapsedMs: performance.now() - startTime,
+            outcome: 'rejected',
+            attempts: attemptDetails
+          })
+
+          return {
+            ok: false,
+            statusCode: 500,
+            error: e
+          }
+        }
+        throw e
+      }
+    }
+
+    // All strategies failed
+    const challenges = failures
+      .map((f) => f.challenge)
+      .filter((c): c is string => typeof c === 'string')
+    const statusCode = failures.find((f) => f.status)?.status || 401
+
+    const result: AuthResult = {
+      ok: false,
+      statusCode,
+      challenges: challenges.length > 0 ? challenges : undefined
+    }
+
+    this.setAuthContext(request, {
+      elapsedMs: performance.now() - startTime,
+      outcome: 'rejected',
+      attempts: attemptDetails
+    })
+
+    return result
+  }
+
+  /**
+   * Attempt a single strategy and return the outcome as an AuthResult.
+   * Uses the same Object.create + callback-patching pattern as AuthenticationRoute.attemptStrategy,
+   * but captures the outcome as data instead of performing side effects.
+   */
+  private attemptStrategyProgrammatic(
+    name: string,
+    baseStrategy: AnyStrategy,
+    request: FastifyRequest,
+    _reply: FastifyReply,
+    options: AuthenticateOptions,
+    failures: { challenge?: string; status?: number }[]
+  ): Promise<AuthResult> {
+    const strategy = Object.create(baseStrategy) as Strategy
+
+    return new Promise<AuthResult>((resolve, reject) => {
+      strategy.success = (user: PassportUser, info?: unknown) => {
+        request.log.debug({ strategy: name }, 'passport programmatic strategy success')
+        resolve({
+          ok: true,
+          strategy: name,
+          statusCode: 200,
+          user,
+          info
+        })
+      }
+
+      strategy.fail = (challengeOrStatus?: string | number, status?: number) => {
+        request.log.trace({ strategy: name }, 'passport programmatic strategy failed')
+        let challenge: string | undefined
+        if (typeof challengeOrStatus === 'number') {
+          status = challengeOrStatus
+          challenge = undefined
+        } else {
+          challenge = challengeOrStatus
+        }
+        failures.push({ challenge, status })
+        reject(Unhandled)
+      }
+
+      strategy.redirect = (url: string, status?: number) => {
+        request.log.trace({ strategy: name, url }, 'passport programmatic strategy redirecting')
+        resolve({
+          ok: false,
+          strategy: name,
+          redirectUrl: url,
+          statusCode: status || 302
+        })
+      }
+
+      strategy.pass = () => {
+        request.log.trace({ strategy: name }, 'passport programmatic strategy passed')
+        // Consistent with hook-based auth: pass() stops the loop
+        resolve({
+          ok: false,
+          strategy: name,
+          statusCode: 200
+        })
+      }
+
+      const error = (err: Error) => {
+        request.log.trace({ strategy: name, errorType: err.name }, 'passport programmatic strategy errored')
+        // Sanitize: strip the original message (may contain tokens/PII from upstream providers)
+        // Preserve only err.name (the error class name, e.g. 'TokenExpiredError') which is safe
+        const sanitized = new Error('Strategy authentication error')
+        sanitized.name = err.name || 'AuthenticationError'
+        reject(sanitized)
+      }
+
+      strategy.error = error
+
+      try {
+        const result = strategy.authenticate(request, options)
+        if (types.isPromise(result)) {
+          result.catch(error)
+        }
+      } catch (err) {
+        error(err as Error)
+      }
+    })
+  }
+
+  /** Resolve a strategy name from a string or Strategy instance. */
+  private resolveStrategyName(nameOrInstance: string | Strategy): string {
+    if (typeof nameOrInstance === 'string') {
+      return nameOrInstance
+    } else if (nameOrInstance.name) {
+      return nameOrInstance.name
+    } else {
+      return nameOrInstance.constructor.name
+    }
+  }
+
+  /** Resolve a strategy prototype from a string name or Strategy instance. */
+  private resolveStrategy(nameOrInstance: string | Strategy): AnyStrategy {
+    if (typeof nameOrInstance === 'string') {
+      const prototype = this.strategies[nameOrInstance]
+      if (!prototype) {
+        throw new Error(
+          `Unknown authentication strategy ${nameOrInstance}, no strategy with this name has been registered.`
+        )
+      }
+      return prototype
+    } else {
+      return nameOrInstance
+    }
+  }
+
+  /** Set the authContext on the request. */
+  private setAuthContext(request: FastifyRequest, context: AuthContext): void {
+    request.authContext = context
+  }
+
+  /**
    * Hook or handler that will authorize a third-party account using the given `strategy` name, with optional `options`.
    *
    * If authorization is successful, the result provided by the strategy's verify callback will be assigned to `request.account`.  The existing login session and `request.user` will be unaffected.
@@ -246,7 +498,7 @@ export class Authenticator {
    *
    * @return {Function} middleware
    */
-  public secureSession (options?: AuthenticateOptions): FastifyPluginAsync {
+  public secureSession(options?: AuthenticateOptions): FastifyPluginAsync {
     return fastifyPlugin(async (fastify) => {
       fastify.addHook('preValidation', new AuthenticationRoute(this, 'session', options).handler)
     })
@@ -325,11 +577,11 @@ export class Authenticator {
    *
    * @api public
    */
-  registerAuthInfoTransformer (fn: InfoTransformerFunction) {
+  registerAuthInfoTransformer(fn: InfoTransformerFunction) {
     this.infoTransformers.push(fn)
   }
 
-  async transformAuthInfo (info: any, request: FastifyRequest) {
+  async transformAuthInfo(info: any, request: FastifyRequest) {
     const result = await this.runStack(this.infoTransformers, info, request)
     // if no transformers are registered (or they all pass), the default behavior is to use the un-transformed info as-is
     return result || info
@@ -342,7 +594,7 @@ export class Authenticator {
    * @return {AnyStrategy}
    * @api private
    */
-  strategy (name: string): AnyStrategy | undefined {
+  strategy(name: string): AnyStrategy | undefined {
     return this.strategies[name]
   }
 

--- a/src/CreateInitializePlugin.ts
+++ b/src/CreateInitializePlugin.ts
@@ -21,5 +21,6 @@ export function CreateInitializePlugin (passport: Authenticator) {
     fastify.decorateRequest('isAuthenticated', isAuthenticated)
     fastify.decorateRequest('isUnauthenticated', isUnauthenticated)
     fastify.decorateRequest(passport.userProperty, null)
+    fastify.decorateRequest('authContext', undefined)
   })
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -4,6 +4,7 @@ import type { logOut } from './decorators/logout'
 import type { isAuthenticated } from './decorators/is-authenticated'
 import type { isUnauthenticated } from './decorators/is-unauthenticated'
 import Authenticator from './Authenticator'
+import type { AuthContext } from './types'
 
 const passport = new Authenticator()
 
@@ -27,7 +28,7 @@ declare module 'fastify' {
    * }
    * ```
    */
-  interface PassportUser {}
+  interface PassportUser { }
 
   interface ExpressSessionData {
     [key: string]: any
@@ -46,9 +47,12 @@ declare module 'fastify' {
     user?: PassportUser
     authInfo?: Record<string, any>
     account?: PassportUser
+    authContext?: AuthContext
   }
 
   interface FastifyReply {
     flash: ReturnType<typeof flashFactory>['reply']
   }
 }
+
+export type { AuthResult, AuthContext } from './types'

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,0 +1,49 @@
+import type { PassportUser } from 'fastify'
+
+/** Result of a programmatic authentication attempt via authenticateRequest(). */
+export interface AuthResult {
+  /** Whether authentication succeeded. */
+  ok: boolean
+  /** Name of the strategy that produced this result. Undefined when all strategies in a multi-strategy attempt failed. */
+  strategy?: string
+  /** The authenticated user object, present only on success. */
+  user?: PassportUser
+  /** Additional data from the strategy's verify callback (e.g., OAuth tokens, scope, messages). Each strategy defines its own schema for this field. */
+  info?: unknown
+  /** HTTP status code for the outcome (e.g. 200 on success, 401 on failure, 302 on redirect, 500 on strategy error). */
+  statusCode: number
+  /** Sanitized error from a strategy that called this.error(). Contains a generic message and the error class name — raw messages are stripped to prevent leaking tokens or credentials. Only present when a strategy signals an infrastructure error. */
+  error?: Error
+  /** WWW-Authenticate challenge strings from failed strategies. Each string describes an authentication scheme the client can use to retry. Only present when all strategies fail. */
+  challenges?: string[]
+  /** Redirect URL if a strategy requested a redirect (e.g. OAuth flow). */
+  redirectUrl?: string
+}
+
+/** Details of a single strategy execution attempt. */
+export interface AuthAttempt {
+  /** Name of the strategy that was attempted. */
+  strategy: string
+  /** Outcome of this specific attempt. */
+  outcome: 'success' | 'fail' | 'pass' | 'error' | 'redirect'
+  /** Time elapsed for this individual attempt in milliseconds. */
+  elapsedMs: number
+  /** Error class name if outcome is 'error' (e.g. 'TokenExpiredError'). */
+  errorType?: string
+}
+
+/** Request-scoped authentication context for audit logging and metrics. */
+export interface AuthContext {
+  /** Name of the strategy that successfully authenticated, undefined if all strategies failed. */
+  successfulStrategy?: string
+  /** Total time elapsed during authentication in milliseconds (across all attempts). */
+  elapsedMs: number
+  /** Overall outcome of the authentication attempt. */
+  outcome: 'authenticated' | 'rejected'
+  /** Safe user identifier (string only, never the full user object). */
+  userId?: string
+  /** Scopes or permissions associated with the authentication. */
+  scopes?: string[]
+  /** Details of each strategy attempt in order. */
+  attempts: AuthAttempt[]
+}

--- a/test/authenticate-request.test.ts
+++ b/test/authenticate-request.test.ts
@@ -1,0 +1,631 @@
+import assert from 'node:assert'
+import { describe, test } from 'node:test'
+import fastify from 'fastify'
+import { getConfiguredTestServer, getRegisteredTestServer } from './helpers'
+import { Strategy } from '../src/strategies'
+import Authenticator from '../src/Authenticator'
+
+/** A strategy that always fails with a challenge string */
+class AlwaysFailStrategy extends Strategy {
+    authenticate() {
+        this.fail('Bearer realm="api"', 401)
+    }
+}
+
+/** A strategy that checks for an x-api-key header */
+class ApiKeyStrategy extends Strategy {
+    authenticate(request: any) {
+        const key = request.headers['x-api-key']
+        if (key === 'valid-key') {
+            return this.success({ id: 'api-user', name: 'API User' })
+        }
+        this.fail('ApiKey', 401)
+    }
+}
+
+/** A strategy that calls this.error() */
+class ErrorStrategy extends Strategy {
+    authenticate() {
+        this.error(new Error('Internal strategy error'))
+    }
+}
+
+/** A strategy that calls this.redirect() */
+class RedirectStrategy extends Strategy {
+    authenticate() {
+        this.redirect('https://oauth.example.com/authorize', 302)
+    }
+}
+
+/** A strategy that calls this.pass() */
+class PassStrategy extends Strategy {
+    authenticate() {
+        this.pass()
+    }
+}
+
+/** A strategy that throws synchronously */
+class ThrowingStrategy extends Strategy {
+    authenticate() {
+        throw new Error('Synchronous explosion')
+    }
+}
+
+describe('authenticateRequest', () => {
+    describe('success cases', () => {
+        test('should return ok:true with user on successful authentication', async () => {
+            const { server, fastifyPassport } = getConfiguredTestServer()
+
+            server.post('/login', async (request, reply) => {
+                const result = await fastifyPassport.authenticateRequest('test', request, reply)
+                reply.send(result)
+            })
+
+            const response = await server.inject({
+                method: 'POST',
+                url: '/login',
+                payload: { login: 'test', password: 'test' }
+            })
+
+            assert.strictEqual(response.statusCode, 200)
+            const body = response.json()
+            assert.strictEqual(body.ok, true)
+            assert.strictEqual(body.strategy, 'test')
+            assert.ok(body.user)
+            assert.strictEqual(body.user.name, 'test')
+        })
+
+        test('should accept a strategy instance directly (not just a name)', async () => {
+            const { server, fastifyPassport } = getRegisteredTestServer()
+            const strategyInstance = new ApiKeyStrategy('api-key')
+
+            server.get('/api', async (request, reply) => {
+                const result = await fastifyPassport.authenticateRequest(strategyInstance, request, reply)
+                reply.send(result)
+            })
+
+            const response = await server.inject({
+                method: 'GET',
+                url: '/api',
+                headers: { 'x-api-key': 'valid-key' }
+            })
+
+            assert.strictEqual(response.statusCode, 200)
+            const body = response.json()
+            assert.strictEqual(body.ok, true)
+            assert.strictEqual(body.strategy, 'api-key')
+            assert.strictEqual(body.user.name, 'API User')
+        })
+
+        test('should NOT set request.user by default (no side effects)', async () => {
+            const { server, fastifyPassport } = getConfiguredTestServer()
+
+            server.post('/login', async (request, reply) => {
+                const result = await fastifyPassport.authenticateRequest('test', request, reply)
+                reply.send({ authResult: result, requestUser: request.user })
+            })
+
+            const response = await server.inject({
+                method: 'POST',
+                url: '/login',
+                payload: { login: 'test', password: 'test' }
+            })
+
+            const body = response.json()
+            assert.strictEqual(body.authResult.ok, true)
+            // request.user should NOT be set — no auto-login
+            assert.ok(!body.requestUser || Object.keys(body.requestUser).length === 0)
+        })
+
+        test('should auto-login when options.session is true', async () => {
+            const { server, fastifyPassport } = getConfiguredTestServer()
+
+            server.post('/login', async (request, reply) => {
+                const result = await fastifyPassport.authenticateRequest('test', request, reply, { session: true })
+                reply.send({ authResult: result, requestUser: request.user })
+            })
+
+            const response = await server.inject({
+                method: 'POST',
+                url: '/login',
+                payload: { login: 'test', password: 'test' }
+            })
+
+            const body = response.json()
+            assert.strictEqual(body.authResult.ok, true)
+            assert.ok(body.requestUser)
+            assert.strictEqual(body.requestUser.name, 'test')
+        })
+
+        test('should explicitly NOT auto-login when options.session is false', async () => {
+            const { server, fastifyPassport } = getConfiguredTestServer()
+
+            server.post('/login', async (request, reply) => {
+                // explicit false
+                const result = await fastifyPassport.authenticateRequest('test', request, reply, { session: false })
+                reply.send({ authResult: result, requestUser: request.user })
+            })
+
+            const response = await server.inject({
+                method: 'POST',
+                url: '/login',
+                payload: { login: 'test', password: 'test' }
+            })
+
+            const body = response.json()
+            assert.strictEqual(body.authResult.ok, true)
+            // request.user should NOT be set
+            assert.ok(!body.requestUser || Object.keys(body.requestUser).length === 0)
+        })
+    })
+
+    describe('failure cases', () => {
+        test('should return ok:false when authentication fails', async () => {
+            const { server, fastifyPassport } = getConfiguredTestServer()
+
+            server.post('/login', async (request, reply) => {
+                const result = await fastifyPassport.authenticateRequest('test', request, reply)
+                reply.send(result)
+            })
+
+            const response = await server.inject({
+                method: 'POST',
+                url: '/login',
+                payload: { login: 'wrong', password: 'wrong' }
+            })
+
+            assert.strictEqual(response.statusCode, 200) // WE control the response, not passport
+            const body = response.json()
+            assert.strictEqual(body.ok, false)
+            assert.strictEqual(body.strategy, undefined)
+            assert.strictEqual(body.statusCode, 401)
+        })
+
+        test('should include challenge strings on failure', async () => {
+            const { server, fastifyPassport } = getRegisteredTestServer()
+            fastifyPassport.use('always-fail', new AlwaysFailStrategy('always-fail'))
+
+            server.get('/protected', async (request, reply) => {
+                const result = await fastifyPassport.authenticateRequest('always-fail', request, reply)
+                reply.send(result)
+            })
+
+            const response = await server.inject({
+                method: 'GET',
+                url: '/protected'
+            })
+
+            const body = response.json()
+            assert.strictEqual(body.ok, false)
+            assert.ok(body.challenges)
+            assert.ok(body.challenges.includes('Bearer realm="api"'))
+        })
+
+        test('should throw error for unknown strategy name', async () => {
+            const { server, fastifyPassport } = getConfiguredTestServer()
+
+            server.get('/test', async (request, reply) => {
+                const result = await fastifyPassport.authenticateRequest('nonexistent', request, reply)
+                reply.send(result)
+            })
+
+            const response = await server.inject({
+                method: 'GET',
+                url: '/test'
+            })
+
+            assert.strictEqual(response.statusCode, 500) // error handler catches the throw
+        })
+    })
+
+    describe('multi-strategy fallback', () => {
+        test('should try strategies in order and stop at first success', async () => {
+            const { server, fastifyPassport } = getRegisteredTestServer()
+            fastifyPassport.use('always-fail', new AlwaysFailStrategy('always-fail'))
+            fastifyPassport.use('api-key', new ApiKeyStrategy('api-key'))
+
+            server.get('/api', async (request, reply) => {
+                const result = await fastifyPassport.authenticateRequest(
+                    ['always-fail', 'api-key'],
+                    request,
+                    reply
+                )
+                reply.send(result)
+            })
+
+            const response = await server.inject({
+                method: 'GET',
+                url: '/api',
+                headers: { 'x-api-key': 'valid-key' }
+            })
+
+            const body = response.json()
+            assert.strictEqual(body.ok, true)
+            assert.strictEqual(body.strategy, 'api-key') // second strategy won
+            assert.strictEqual(body.user.name, 'API User')
+        })
+
+        test('should return failure with all challenges when all strategies fail', async () => {
+            const { server, fastifyPassport } = getRegisteredTestServer()
+            fastifyPassport.use('fail-1', new AlwaysFailStrategy('fail-1'))
+            fastifyPassport.use('fail-2', new AlwaysFailStrategy('fail-2'))
+
+            server.get('/api', async (request, reply) => {
+                const result = await fastifyPassport.authenticateRequest(
+                    ['fail-1', 'fail-2'],
+                    request,
+                    reply
+                )
+                reply.send(result)
+            })
+
+            const response = await server.inject({
+                method: 'GET',
+                url: '/api'
+            })
+
+            const body = response.json()
+            assert.strictEqual(body.ok, false)
+            assert.strictEqual(body.strategy, undefined)
+            assert.strictEqual(body.statusCode, 401)
+            assert.ok(body.challenges)
+            assert.strictEqual(body.challenges.length, 2)
+        })
+    })
+
+    describe('strategy callbacks', () => {
+        test('should handle strategy error with sanitized error', async () => {
+            const { server, fastifyPassport } = getRegisteredTestServer()
+            fastifyPassport.use('error-strategy', new ErrorStrategy('error-strategy'))
+
+            server.get('/test', async (request, reply) => {
+                const result = await fastifyPassport.authenticateRequest('error-strategy', request, reply)
+                reply.send({
+                    ok: result.ok,
+                    statusCode: result.statusCode,
+                    errorMessage: result.error?.message,
+                    authContext: (request as any).authContext
+                })
+            })
+
+            const response = await server.inject({
+                method: 'GET',
+                url: '/test'
+            })
+
+            const body = response.json()
+            assert.strictEqual(body.ok, false)
+            assert.strictEqual(body.statusCode, 500)
+            assert.strictEqual(body.errorMessage, 'Strategy authentication error')
+            assert.strictEqual(body.authContext.attempts[0].outcome, 'error')
+            assert.strictEqual(body.authContext.attempts[0].errorType, 'Error')
+        })
+
+        test('should handle strategy redirect', async () => {
+            const { server, fastifyPassport } = getRegisteredTestServer()
+            fastifyPassport.use('redirect-strategy', new RedirectStrategy('redirect-strategy'))
+
+            server.get('/oauth', async (request, reply) => {
+                const result = await fastifyPassport.authenticateRequest('redirect-strategy', request, reply)
+                reply.send(result)
+            })
+
+            const response = await server.inject({
+                method: 'GET',
+                url: '/oauth'
+            })
+
+            const body = response.json()
+            assert.strictEqual(body.ok, false)
+            assert.strictEqual(body.strategy, 'redirect-strategy')
+            assert.strictEqual(body.redirectUrl, 'https://oauth.example.com/authorize')
+            assert.strictEqual(body.statusCode, 302)
+        })
+
+        test('should handle strategy pass (stops the loop)', async () => {
+            const { server, fastifyPassport } = getRegisteredTestServer()
+            fastifyPassport.use('pass-strategy', new PassStrategy('pass-strategy'))
+
+            server.get('/test', async (request, reply) => {
+                const result = await fastifyPassport.authenticateRequest('pass-strategy', request, reply)
+                reply.send(result)
+            })
+
+            const response = await server.inject({
+                method: 'GET',
+                url: '/test'
+            })
+
+            const body = response.json()
+            assert.strictEqual(body.ok, false)
+            assert.strictEqual(body.strategy, 'pass-strategy')
+        })
+
+        test('should handle synchronous throw in strategy.authenticate()', async () => {
+            const { server, fastifyPassport } = getRegisteredTestServer()
+            fastifyPassport.use('throwing', new ThrowingStrategy('throwing'))
+
+            server.get('/test', async (request, reply) => {
+                const result = await fastifyPassport.authenticateRequest('throwing', request, reply)
+                reply.send({ ok: result.ok, statusCode: result.statusCode, errorMessage: result.error?.message })
+            })
+
+            const response = await server.inject({
+                method: 'GET',
+                url: '/test'
+            })
+
+            const body = response.json()
+            assert.strictEqual(body.ok, false)
+            assert.strictEqual(body.statusCode, 500)
+            assert.strictEqual(body.errorMessage, 'Strategy authentication error')
+        })
+    })
+
+    describe('authContext', () => {
+        test('should populate request.authContext on success', async () => {
+            const { server, fastifyPassport } = getConfiguredTestServer()
+
+            server.post('/login', async (request, reply) => {
+                await fastifyPassport.authenticateRequest('test', request, reply)
+                reply.send(request.authContext)
+            })
+
+            const response = await server.inject({
+                method: 'POST',
+                url: '/login',
+                payload: { login: 'test', password: 'test' }
+            })
+
+            const body = response.json()
+            assert.strictEqual(body.successfulStrategy, 'test')
+            assert.strictEqual(body.outcome, 'authenticated')
+            assert.strictEqual(body.attempts.length, 1)
+            assert.strictEqual(body.attempts[0].strategy, 'test')
+            assert.strictEqual(body.attempts[0].outcome, 'success')
+            assert.ok(typeof body.elapsedMs === 'number')
+            assert.ok(body.elapsedMs >= 0)
+        })
+
+        test('should populate request.authContext on failure', async () => {
+            const { server, fastifyPassport } = getConfiguredTestServer()
+
+            server.post('/login', async (request, reply) => {
+                await fastifyPassport.authenticateRequest('test', request, reply)
+                reply.send(request.authContext)
+            })
+
+            const response = await server.inject({
+                method: 'POST',
+                url: '/login',
+                payload: { login: 'wrong', password: 'wrong' }
+            })
+
+            const body = response.json()
+            assert.strictEqual(body.successfulStrategy, undefined)
+            assert.strictEqual(body.outcome, 'rejected')
+            assert.strictEqual(body.attempts.length, 1)
+            assert.strictEqual(body.attempts[0].strategy, 'test')
+            assert.strictEqual(body.attempts[0].outcome, 'fail')
+        })
+
+        test('should track correct attempt count in multi-strategy', async () => {
+            const { server, fastifyPassport } = getRegisteredTestServer()
+            fastifyPassport.use('always-fail', new AlwaysFailStrategy('always-fail'))
+            fastifyPassport.use('api-key', new ApiKeyStrategy('api-key'))
+
+            server.get('/api', async (request, reply) => {
+                await fastifyPassport.authenticateRequest(
+                    ['always-fail', 'api-key'],
+                    request,
+                    reply
+                )
+                reply.send(request.authContext)
+            })
+
+            const response = await server.inject({
+                method: 'GET',
+                url: '/api',
+                headers: { 'x-api-key': 'valid-key' }
+            })
+
+            const body = response.json()
+            assert.strictEqual(body.successfulStrategy, 'api-key')
+            assert.strictEqual(body.attempts.length, 2)
+            assert.strictEqual(body.attempts[0].strategy, 'always-fail')
+            assert.strictEqual(body.attempts[0].outcome, 'fail')
+            assert.strictEqual(body.attempts[1].strategy, 'api-key')
+            assert.strictEqual(body.attempts[1].outcome, 'success')
+            assert.strictEqual(body.outcome, 'authenticated')
+        })
+
+        test('should isolate authContext across concurrent requests', async () => {
+            const { server, fastifyPassport } = getConfiguredTestServer()
+            fastifyPassport.use('api-key', new ApiKeyStrategy('api-key'))
+
+            server.post('/delayed-login', async (request, reply) => {
+                await fastifyPassport.authenticateRequest('test', request, reply)
+                // Artificial delay to ensure the second request runs while this one is yielding
+                await new Promise(resolve => setTimeout(resolve, 50))
+                reply.send(request.authContext)
+            })
+
+            server.get('/fast-api', async (request, reply) => {
+                await fastifyPassport.authenticateRequest('api-key', request, reply)
+                reply.send(request.authContext)
+            })
+
+            // Fire both requests concurrently
+            const [delayedLoginResponse, fastApiResponse] = await Promise.all([
+                server.inject({
+                    method: 'POST',
+                    url: '/delayed-login',
+                    payload: { login: 'test', password: 'test' }
+                }),
+                server.inject({
+                    method: 'GET',
+                    url: '/fast-api',
+                    headers: { 'x-api-key': 'valid-key' }
+                })
+            ])
+
+            const loginContext = delayedLoginResponse.json()
+            const apiContext = fastApiResponse.json()
+
+            // If there is cross-request bleed, loginContext.successfulStrategy
+            // will have been overwritten by 'api-key' during the delay.
+            assert.strictEqual(loginContext.successfulStrategy, 'test')
+            assert.strictEqual(apiContext.successfulStrategy, 'api-key')
+        })
+    })
+
+    describe('edge cases', () => {
+        test('should throw when passport.initialize() was not called', async () => {
+            const server = fastify()
+            const passport = new Authenticator()
+            passport.use('test', new ApiKeyStrategy('test'))
+
+            // Do NOT call server.register(passport.initialize())
+            server.get('/test', async (request: any, reply: any) => {
+                const result = await passport.authenticateRequest('test', request, reply)
+                reply.send(result)
+            })
+
+            const response = await server.inject({
+                method: 'GET',
+                url: '/test'
+            })
+
+            assert.strictEqual(response.statusCode, 500)
+            const body = response.json()
+            assert.ok(body.message.includes('passport.initialize()'))
+        })
+
+        test('should throw when empty strategy array is passed', async () => {
+            const { server, fastifyPassport } = getRegisteredTestServer()
+
+            server.get('/test', async (request, reply) => {
+                const result = await fastifyPassport.authenticateRequest([] as any, request, reply)
+                reply.send(result)
+            })
+
+            const response = await server.inject({
+                method: 'GET',
+                url: '/test'
+            })
+
+            assert.strictEqual(response.statusCode, 500)
+            const body = response.json()
+            assert.ok(body.message.includes('at least one strategy'))
+        })
+
+        test('should rethrow non-Unhandled errors from strategy loop', async () => {
+            /** A strategy that throws a real error (not via this.error(), but outside the callback bridge) */
+            class RealErrorStrategy extends Strategy {
+                authenticate() {
+                    // Throw after a microtick to escape the try/catch in attemptStrategyProgrammatic
+                    // but this is caught by the promise catch
+                    throw new Error('Real non-strategy error')
+                }
+            }
+
+            const { server, fastifyPassport } = getConfiguredTestServer()
+            fastifyPassport.use('real-error', new RealErrorStrategy('real-error'))
+
+            server.get('/test', async (request, reply) => {
+                const result = await fastifyPassport.authenticateRequest('real-error', request, reply)
+                reply.send({ ok: result.ok, statusCode: result.statusCode, errorMessage: result.error?.message })
+            })
+
+            const response = await server.inject({
+                method: 'GET',
+                url: '/test'
+            })
+
+            const body = response.json()
+            assert.strictEqual(body.ok, false)
+            assert.strictEqual(body.statusCode, 500)
+            assert.strictEqual(body.errorMessage, 'Strategy authentication error')
+        })
+
+        test('should handle fail() with numeric-only challenge', async () => {
+            class NumericFailStrategy extends Strategy {
+                authenticate() {
+                    this.fail(403)
+                }
+            }
+
+            const { server, fastifyPassport } = getRegisteredTestServer()
+            fastifyPassport.use('numeric-fail', new NumericFailStrategy('numeric-fail'))
+
+            server.get('/test', async (request, reply) => {
+                const result = await fastifyPassport.authenticateRequest('numeric-fail', request, reply)
+                reply.send(result)
+            })
+
+            const response = await server.inject({
+                method: 'GET',
+                url: '/test'
+            })
+
+            const body = response.json()
+            assert.strictEqual(body.ok, false)
+            assert.strictEqual(body.statusCode, 403)
+        })
+
+        test('should handle async strategy that returns a rejected promise', async () => {
+            class AsyncRejectStrategy extends Strategy {
+                authenticate() {
+                    return Promise.reject(new Error('Async rejection'))
+                }
+            }
+
+            const { server, fastifyPassport } = getRegisteredTestServer()
+            fastifyPassport.use('async-reject', new AsyncRejectStrategy('async-reject'))
+
+            server.get('/test', async (request, reply) => {
+                const result = await fastifyPassport.authenticateRequest('async-reject', request, reply)
+                reply.send({ ok: result.ok, statusCode: result.statusCode, errorMessage: result.error?.message })
+            })
+
+            const response = await server.inject({
+                method: 'GET',
+                url: '/test'
+            })
+
+            const body = response.json()
+            assert.strictEqual(body.ok, false)
+            assert.strictEqual(body.statusCode, 500)
+            assert.strictEqual(body.errorMessage, 'Strategy authentication error')
+        })
+
+        test('should use constructor.name when strategy instance has no name property', async () => {
+            class UnNamedStrategy extends Strategy {
+                constructor() {
+                    super('')  // empty name
+                }
+
+                authenticate(request: any) {
+                    this.success({ id: 'nameless', name: 'Nameless User' })
+                }
+            }
+
+            const { server, fastifyPassport } = getRegisteredTestServer()
+            const instance = new UnNamedStrategy()
+
+            server.get('/test', async (request, reply) => {
+                const result = await fastifyPassport.authenticateRequest(instance, request, reply)
+                reply.send(result)
+            })
+
+            const response = await server.inject({
+                method: 'GET',
+                url: '/test'
+            })
+
+            const body = response.json()
+            assert.strictEqual(body.ok, true)
+            assert.strictEqual(body.strategy, 'UnNamedStrategy')
+        })
+    })
+})


### PR DESCRIPTION
Implement promise based authenticateRequest() API that enables programmatic execution of Passport strategies

Key additions:
- Returns an explicit `AuthResult` object containing the resolution of the auth  attempt
- Adds an AuthContext to capture and provide data for logging and metrics
- Maintains backwards compatibility with hook logic
- Includes demo-auth-server.ts to test the code

Testing
Demo server created
<img width="1081" height="392" alt="image" src="https://github.com/user-attachments/assets/9ea9f0d3-8e7e-4474-bcfe-0c2bc77093e5" />

Calling the route with the invalid Api Key before logging in to get a session cookie results in both strategies failing
<img width="1895" height="1122" alt="image" src="https://github.com/user-attachments/assets/43b358a0-e0db-403f-a44e-a28b8290563b" />

Calling the route with the valid API Key before logging in to get a session cookie results in the session key failing, then the API key authentication succeeding
<img width="1897" height="1091" alt="image" src="https://github.com/user-attachments/assets/493e5f91-b6de-415f-85bd-67ebf23bd4a2" />

If we then hit the login route
<img width="1899" height="1065" alt="image" src="https://github.com/user-attachments/assets/c321cce9-f8ff-427b-91f1-4c639172f357" />

We now have a cookie with a valid session so if we attempt authentication with the valid or invalid key, authentication will pass since it attempts to use session before even using the API keys
<img width="1896" height="697" alt="image" src="https://github.com/user-attachments/assets/f3fa1bb1-954d-4a9d-8d90-59f105f0ffc0" />
<img width="1888" height="615" alt="image" src="https://github.com/user-attachments/assets/ddc01447-fd6a-419c-ac27-083b0cc550e3" />

If we then logout, our session will be cleared and we can see that we will fall  back to the API key auth again and we get the original results above
<img width="1893" height="509" alt="image" src="https://github.com/user-attachments/assets/2599197f-5a83-48c4-9402-f68c4a35e0c6" />
<img width="1899" height="719" alt="image" src="https://github.com/user-attachments/assets/1140e03a-5102-454f-af82-45cf0b9a12ea" />
<img width="1889" height="645" alt="image" src="https://github.com/user-attachments/assets/7bcc1261-04b4-408c-ae8d-d6c05692096b" />


