### PR TITLE
fix: support TypeScript imports in ESM and CommonJS

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,8 @@
     "lint": "eslint",
     "lint:fix": "eslint --fix",
     "prepublishOnly": "npm run build",
-    "test": "npm run build:test && npm run test:unit",
+    "test": "npm run test:types && npm run build:test && npm run test:unit",
+    "test:types": "npm run build && tstyche",
     "test:unit": "borp --coverage --lines 100"
   },
   "repository": {
@@ -58,6 +59,7 @@
     "passport-google-oauth": "^2.0.0",
     "rimraf": "^6.0.1",
     "set-cookie-parser": "^3.0.1",
+    "tstyche": "^7.2.2",
     "typescript": "~6.0.2"
   },
   "files": [

--- a/src/index.ts
+++ b/src/index.ts
@@ -4,14 +4,17 @@ import type { logOut } from './decorators/logout'
 import type { isAuthenticated } from './decorators/is-authenticated'
 import type { isUnauthenticated } from './decorators/is-unauthenticated'
 import Authenticator from './Authenticator'
+import { Strategy } from './strategies/base'
 
 const passport = new Authenticator()
+const exportedPassport = Object.assign(passport, { default: passport, Authenticator, Strategy })
 
-// Workaround for importing fastify-passport in native ESM context
-module.exports = exports = passport
-export default passport
-export { Strategy } from './strategies/base'
-export { Authenticator } from './Authenticator'
+// Expose named exports to Node.js' CommonJS named-export detection.
+module.exports.default = passport
+module.exports.Authenticator = Authenticator
+module.exports.Strategy = Strategy
+
+export = exportedPassport
 
 declare module 'fastify' {
   /**

--- a/test/types/commonjs.tst.cts
+++ b/test/types/commonjs.tst.cts
@@ -7,8 +7,6 @@ expect(fastifyPassport).type.toHaveProperty('initialize')
 expect(fastifyPassport.initialize).type.toBeCallableWith()
 expect(fastifyPassport.authenticate).type.toBeCallableWith('test')
 expect(fastifyPassport.default).type.toHaveProperty('initialize')
-expect(fastifyPassport.Authenticator).type.toBeConstructableWith()
-expect(fastifyPassport.Strategy).type.toBeConstructableWith('test')
 expect(Authenticator).type.toBeConstructableWith()
 expect(Strategy).type.toBeConstructableWith('test')
 

--- a/test/types/commonjs.tst.cts
+++ b/test/types/commonjs.tst.cts
@@ -1,6 +1,7 @@
 import { expect } from 'tstyche'
-import { Authenticator, Strategy } from '../../dist/index.js'
 import fastifyPassport = require('../../dist/index.js')
+
+const { Authenticator, Strategy } = fastifyPassport
 
 expect(fastifyPassport).type.toHaveProperty('initialize')
 expect(fastifyPassport.initialize).type.toBeCallableWith()

--- a/test/types/commonjs.tst.cts
+++ b/test/types/commonjs.tst.cts
@@ -1,0 +1,18 @@
+import { expect } from 'tstyche'
+import fastifyPassport = require('../../dist/index.js')
+
+expect(fastifyPassport).type.toHaveProperty('initialize')
+expect(fastifyPassport.initialize).type.toBeCallableWith()
+expect(fastifyPassport.authenticate).type.toBeCallableWith('test')
+expect(fastifyPassport.default).type.toHaveProperty('initialize')
+expect(fastifyPassport.Authenticator).type.toBeConstructableWith()
+expect(fastifyPassport.Strategy).type.toBeConstructableWith('test')
+
+fastifyPassport.registerUserSerializer(async user => user)
+fastifyPassport.registerUserDeserializer(async user => user)
+
+class TestStrategy extends fastifyPassport.Strategy {
+  authenticate (): void {}
+}
+
+new TestStrategy('test')

--- a/test/types/commonjs.tst.cts
+++ b/test/types/commonjs.tst.cts
@@ -1,4 +1,5 @@
 import { expect } from 'tstyche'
+import { Authenticator, Strategy } from '../../dist/index.js'
 import fastifyPassport = require('../../dist/index.js')
 
 expect(fastifyPassport).type.toHaveProperty('initialize')
@@ -7,6 +8,8 @@ expect(fastifyPassport.authenticate).type.toBeCallableWith('test')
 expect(fastifyPassport.default).type.toHaveProperty('initialize')
 expect(fastifyPassport.Authenticator).type.toBeConstructableWith()
 expect(fastifyPassport.Strategy).type.toBeConstructableWith('test')
+expect(Authenticator).type.toBeConstructableWith()
+expect(Strategy).type.toBeConstructableWith('test')
 
 expect(fastifyPassport.registerUserSerializer).type.toBeCallableWith(async (user: unknown) => user)
 expect(fastifyPassport.registerUserDeserializer).type.toBeCallableWith(async (user: unknown) => user)

--- a/test/types/commonjs.tst.cts
+++ b/test/types/commonjs.tst.cts
@@ -8,11 +8,11 @@ expect(fastifyPassport.default).type.toHaveProperty('initialize')
 expect(fastifyPassport.Authenticator).type.toBeConstructableWith()
 expect(fastifyPassport.Strategy).type.toBeConstructableWith('test')
 
-fastifyPassport.registerUserSerializer(async user => user)
-fastifyPassport.registerUserDeserializer(async user => user)
+expect(fastifyPassport.registerUserSerializer).type.toBeCallableWith(async (user: unknown) => user)
+expect(fastifyPassport.registerUserDeserializer).type.toBeCallableWith(async (user: unknown) => user)
 
 class TestStrategy extends fastifyPassport.Strategy {
   authenticate (): void {}
 }
 
-new TestStrategy('test')
+expect(TestStrategy).type.toBeConstructableWith('test')

--- a/test/types/esm.tst.mts
+++ b/test/types/esm.tst.mts
@@ -7,11 +7,11 @@ expect(fastifyPassport.authenticate).type.toBeCallableWith('test')
 expect(Authenticator).type.toBeConstructableWith()
 expect(Strategy).type.toBeConstructableWith('test')
 
-fastifyPassport.registerUserSerializer(async user => user)
-fastifyPassport.registerUserDeserializer(async user => user)
+expect(fastifyPassport.registerUserSerializer).type.toBeCallableWith(async (user: unknown) => user)
+expect(fastifyPassport.registerUserDeserializer).type.toBeCallableWith(async (user: unknown) => user)
 
 class TestStrategy extends Strategy {
   authenticate (): void {}
 }
 
-new TestStrategy('test')
+expect(TestStrategy).type.toBeConstructableWith('test')

--- a/test/types/esm.tst.mts
+++ b/test/types/esm.tst.mts
@@ -1,0 +1,17 @@
+import { expect } from 'tstyche'
+import fastifyPassport, { Authenticator, Strategy } from '../../dist/index.js'
+
+expect(fastifyPassport).type.toHaveProperty('initialize')
+expect(fastifyPassport.initialize).type.toBeCallableWith()
+expect(fastifyPassport.authenticate).type.toBeCallableWith('test')
+expect(Authenticator).type.toBeConstructableWith()
+expect(Strategy).type.toBeConstructableWith('test')
+
+fastifyPassport.registerUserSerializer(async user => user)
+fastifyPassport.registerUserDeserializer(async user => user)
+
+class TestStrategy extends Strategy {
+  authenticate (): void {}
+}
+
+new TestStrategy('test')

--- a/test/types/tsconfig.json
+++ b/test/types/tsconfig.json
@@ -1,0 +1,11 @@
+{
+  "compilerOptions": {
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "target": "ES2022",
+    "strict": true,
+    "skipLibCheck": true,
+    "noEmit": true
+  },
+  "include": ["*.mts", "*.cts"]
+}

--- a/tsconfig.test.json
+++ b/tsconfig.test.json
@@ -19,8 +19,8 @@
     "noFallthroughCasesInSwitch": true,
     "isolatedModules": true,
     "forceConsistentCasingInFileNames": true,
-    "skipLibCheck": true,
-    "erasableSyntaxOnly": true
+    "skipLibCheck": true
   },
-  "include": ["src", "test"]
+  "include": ["src", "test"],
+  "exclude": ["test/types"]
 }


### PR DESCRIPTION
## Summary

- generate the package export declaration from the TypeScript entry point
- preserve default and named exports for ESM and CommonJS consumers
- add TSTyche coverage for both module systems

## Testing

- npm test
- npm run lint
- npx tstyche --target 5.7

Fixes #1319