### PR TITLE
fix(types): restore route hook compatibility

### DIFF
--- a/src/AuthenticationRoute.ts
+++ b/src/AuthenticationRoute.ts
@@ -3,7 +3,7 @@ import type { Authenticator } from './Authenticator'
 import type { AnyStrategy } from './strategies'
 import type { Strategy } from './strategies/base'
 import { AuthenticationError } from './errors'
-import type { FastifyReply, FastifyRequest } from 'fastify'
+import type { FastifyReply, FastifyRequest, preValidationAsyncHookHandler } from 'fastify'
 import { types } from 'node:util'
 
 type FlashObject = { type?: string; message?: string }
@@ -102,7 +102,7 @@ export class AuthenticationRoute<StrategyOrStrategies extends string | Strategy 
     }
   }
 
-  handler = async (request: FastifyRequest, reply: FastifyReply) => {
+  handler: preValidationAsyncHookHandler = async (request: FastifyRequest, reply: FastifyReply) => {
     if (!request.passport) {
       throw new Error('passport.initialize() plugin not in use')
     }

--- a/src/Authenticator.ts
+++ b/src/Authenticator.ts
@@ -1,4 +1,4 @@
-import type { FastifyPluginAsync, FastifyRequest, RouteHandlerMethod } from 'fastify'
+import type { FastifyPluginAsync, FastifyRequest, preValidationAsyncHookHandler } from 'fastify'
 import { fastifyPlugin } from 'fastify-plugin'
 import { type AuthenticateCallback, type AuthenticateOptions, AuthenticationRoute } from './AuthenticationRoute'
 import { CreateInitializePlugin } from './CreateInitializePlugin'
@@ -148,21 +148,21 @@ export class Authenticator {
   public authenticate<StrategyOrStrategies extends string | Strategy | (string | Strategy)[]>(
     strategy: StrategyOrStrategies,
     callback?: AuthenticateCallback<StrategyOrStrategies>
-  ): RouteHandlerMethod
+  ): preValidationAsyncHookHandler
   public authenticate<StrategyOrStrategies extends string | Strategy | (string | Strategy)[]>(
     strategy: StrategyOrStrategies,
     options?: AuthenticateOptions
-  ): RouteHandlerMethod
+  ): preValidationAsyncHookHandler
   public authenticate<StrategyOrStrategies extends string | Strategy | (string | Strategy)[]>(
     strategy: StrategyOrStrategies,
     options?: AuthenticateOptions,
     callback?: AuthenticateCallback<StrategyOrStrategies>
-  ): RouteHandlerMethod
+  ): preValidationAsyncHookHandler
   public authenticate<StrategyOrStrategies extends string | Strategy | (string | Strategy)[]>(
     strategyOrStrategies: StrategyOrStrategies,
     optionsOrCallback?: AuthenticateOptions | AuthenticateCallback<StrategyOrStrategies>,
     callback?: AuthenticateCallback<StrategyOrStrategies>
-  ): RouteHandlerMethod {
+  ): preValidationAsyncHookHandler {
     let options: AuthenticateOptions | undefined
     if (typeof optionsOrCallback === 'function') {
       options = {}
@@ -194,21 +194,21 @@ export class Authenticator {
   public authorize<StrategyOrStrategies extends string | Strategy | (string | Strategy)[]>(
     strategy: StrategyOrStrategies,
     callback?: AuthenticateCallback<StrategyOrStrategies>
-  ): RouteHandlerMethod
+  ): preValidationAsyncHookHandler
   public authorize<StrategyOrStrategies extends string | Strategy | (string | Strategy)[]>(
     strategy: StrategyOrStrategies,
     options?: AuthenticateOptions
-  ): RouteHandlerMethod
+  ): preValidationAsyncHookHandler
   public authorize<StrategyOrStrategies extends string | Strategy | (string | Strategy)[]>(
     strategy: StrategyOrStrategies,
     options?: AuthenticateOptions,
     callback?: AuthenticateCallback<StrategyOrStrategies>
-  ): RouteHandlerMethod
+  ): preValidationAsyncHookHandler
   public authorize<StrategyOrStrategies extends string | Strategy | (string | Strategy)[]>(
     strategyOrStrategies: StrategyOrStrategies,
     optionsOrCallback?: AuthenticateOptions | AuthenticateCallback<StrategyOrStrategies>,
     callback?: AuthenticateCallback<StrategyOrStrategies>
-  ): RouteHandlerMethod {
+  ): preValidationAsyncHookHandler {
     let options: AuthenticateOptions | undefined
     if (typeof optionsOrCallback === 'function') {
       options = {}

--- a/test/authentication-route.test.ts
+++ b/test/authentication-route.test.ts
@@ -1,7 +1,6 @@
 import assert from 'node:assert'
 import { describe, test } from 'node:test'
 import { getConfiguredTestServer, TestStrategy } from './helpers'
-import { preValidationHookHandler } from 'fastify'
 
 describe('AuthenticationRoute edge cases', () => {
   test('should use failWithError option to throw error on authentication failure', async () => {
@@ -12,7 +11,7 @@ describe('AuthenticationRoute edge cases', () => {
       {
         preValidation: fastifyPassport.authenticate('test', {
           failWithError: true
-        }) as preValidationHookHandler
+        })
       },
       async () => assert.fail('should not reach here')
     )
@@ -37,7 +36,7 @@ describe('AuthenticationRoute edge cases', () => {
 
     server.post(
       '/login',
-      { preValidation: fastifyPassport.authenticate('challenge') as preValidationHookHandler },
+      { preValidation: fastifyPassport.authenticate('challenge') },
       async () => assert.fail('should not reach here')
     )
 
@@ -73,7 +72,7 @@ describe('AuthenticationRoute edge cases', () => {
 
     server.post(
       '/login',
-      { preValidation: fastifyPassport.authenticate(['first', 'second']) as preValidationHookHandler },
+      { preValidation: fastifyPassport.authenticate(['first', 'second']) },
       async () => 'should not reach here'
     )
 
@@ -122,7 +121,7 @@ describe('AuthenticationRoute edge cases', () => {
 
     server.post(
       '/login',
-      { preValidation: fastifyPassport.authenticate('nonexistent') as preValidationHookHandler },
+      { preValidation: fastifyPassport.authenticate('nonexistent') },
       async () => assert.fail('should not reach here')
     )
 
@@ -147,7 +146,7 @@ describe('AuthenticationRoute edge cases', () => {
 
     server.post(
       '/login',
-      { preValidation: fastifyPassport.authenticate(strategy) as preValidationHookHandler },
+      { preValidation: fastifyPassport.authenticate(strategy) },
       async (request: any) => (request.user as any).name
     )
 
@@ -171,7 +170,7 @@ describe('AuthenticationRoute edge cases', () => {
 
     server.post(
       '/login',
-      { preValidation: fastifyPassport.authenticate('custom') as preValidationHookHandler },
+      { preValidation: fastifyPassport.authenticate('custom') },
       async () => 'should not reach here'
     )
 
@@ -194,7 +193,7 @@ describe('AuthenticationRoute edge cases', () => {
 
     server.post(
       '/login',
-      { preValidation: fastifyPassport.authenticate('object') as preValidationHookHandler },
+      { preValidation: fastifyPassport.authenticate('object') },
       async () => assert.fail('should not reach here')
     )
 
@@ -225,7 +224,7 @@ describe('AuthenticationRoute edge cases', () => {
 
     server.post(
       '/login',
-      { preValidation: fastifyPassport.authenticate(strategy) as preValidationHookHandler },
+      { preValidation: fastifyPassport.authenticate(strategy) },
       async (request: any) => (request.user as any).name
     )
 

--- a/test/authenticator.test.ts
+++ b/test/authenticator.test.ts
@@ -2,7 +2,6 @@ import assert from 'node:assert'
 import { describe, test } from 'node:test'
 import Authenticator from '../src/Authenticator'
 import { getConfiguredTestServer } from './helpers'
-import { preValidationHookHandler } from 'fastify'
 
 describe('Authenticator edge cases', () => {
   test('should throw error when no serializer succeeds', async () => {
@@ -34,7 +33,7 @@ describe('Authenticator edge cases', () => {
       {
         preValidation: fastifyPassport.authorize('test', {
           assignProperty: 'account'
-        }) as preValidationHookHandler
+        })
       },
       async (request: any, reply) => {
         reply.send({ account: request.account })
@@ -51,6 +50,28 @@ describe('Authenticator edge cases', () => {
     const body = response.json()
     assert.ok(body.account)
     assert.strictEqual(body.account.name, 'test')
+  })
+
+  test('should use authenticate as preValidation with a typed querystring', async (t) => {
+    const { server, fastifyPassport } = getConfiguredTestServer()
+    t.after(() => server.close())
+
+    server.post<{ Querystring: { returnTo: string } }>(
+      '/login',
+      {
+        preValidation: fastifyPassport.authenticate('test', { authInfo: false })
+      },
+      async (request) => request.query.returnTo
+    )
+
+    const response = await server.inject({
+      method: 'POST',
+      payload: { login: 'test', password: 'test' },
+      url: '/login?returnTo=account'
+    })
+
+    assert.strictEqual(response.statusCode, 200)
+    assert.strictEqual(response.body, 'account')
   })
 
   test('should handle authorize with callback function as second parameter', async () => {

--- a/test/authorize.test.ts
+++ b/test/authorize.test.ts
@@ -2,7 +2,6 @@ import { test, describe } from 'node:test'
 import assert from 'node:assert'
 import { Strategy } from '../src/strategies'
 import { generateTestUser, getConfiguredTestServer } from './helpers'
-import { preValidationHookHandler } from 'fastify'
 
 export class TestThirdPartyStrategy extends Strategy {
   authenticate (_request: any, _options?: { pauseStream?: boolean }) {
@@ -18,7 +17,7 @@ const testSuite = (sessionPluginName: string) => {
         fastifyPassport.use(new TestThirdPartyStrategy('third-party'))
         server.get(
           '/',
-          { preValidation: fastifyPassport.authorize('third-party') as preValidationHookHandler },
+          { preValidation: fastifyPassport.authorize('third-party') },
           async (request) => {
             const user = request.user as any
             assert.ifError(user)

--- a/test/base-strategy.test.ts
+++ b/test/base-strategy.test.ts
@@ -2,7 +2,6 @@ import assert from 'node:assert'
 import { describe, test } from 'node:test'
 import { Strategy } from '../src/strategies/base'
 import { getConfiguredTestServer } from './helpers'
-import { preValidationHookHandler } from 'fastify'
 
 describe('Additional coverage tests', () => {
   test('should use constructor name when strategy instance has no name property', async () => {
@@ -26,7 +25,7 @@ describe('Additional coverage tests', () => {
 
     server.post(
       '/login',
-      { preValidation: fastifyPassport.authenticate(strategy) as preValidationHookHandler },
+      { preValidation: fastifyPassport.authenticate(strategy) },
       async (request: any) => (request.user as any).name
     )
 

--- a/test/csrf-fixation.test.ts
+++ b/test/csrf-fixation.test.ts
@@ -2,7 +2,6 @@ import { test, describe, beforeEach } from 'node:test'
 import assert from 'node:assert'
 import { getConfiguredTestServer, TestBrowserSession } from './helpers'
 import fastifyCsrfProtection from '@fastify/csrf-protection'
-import { preValidationHookHandler } from 'fastify'
 
 function createServer (sessionPluginName: '@fastify/session' | '@fastify/secure-session') {
   const { server, fastifyPassport } = getConfiguredTestServer()
@@ -11,7 +10,7 @@ function createServer (sessionPluginName: '@fastify/session' | '@fastify/secure-
 
   server.post(
     '/login',
-    { preValidation: fastifyPassport.authenticate('test', { authInfo: false }) as preValidationHookHandler },
+    { preValidation: fastifyPassport.authenticate('test', { authInfo: false }) },
     async () => 'success'
   )
 

--- a/test/decorators.test.ts
+++ b/test/decorators.test.ts
@@ -2,7 +2,6 @@ import assert from 'node:assert'
 import { describe, test } from 'node:test'
 import '../src/index'
 import { getConfiguredTestServer, TestStrategy } from './helpers'
-import { preValidationHookHandler } from 'fastify'
 
 const testSuite = (sessionPluginName: string) => {
   describe(`${sessionPluginName} tests`, () => {
@@ -17,7 +16,7 @@ const testSuite = (sessionPluginName: string) => {
           {
             preValidation: fastifyPassport.authenticate('test', {
               authInfo: false
-            }) as preValidationHookHandler
+            })
           },
           async (request) => (request.user as any).name
         )
@@ -130,7 +129,7 @@ const testSuite = (sessionPluginName: string) => {
           {
             preValidation: fastifyPassport.authenticate('test', {
               authInfo: false
-            }) as preValidationHookHandler
+            })
           },
           async () => 'the root!'
         )
@@ -139,7 +138,7 @@ const testSuite = (sessionPluginName: string) => {
           {
             preValidation: fastifyPassport.authenticate('test', {
               authInfo: false
-            }) as preValidationHookHandler
+            })
           },
           async (request, reply) => {
             request.logout()
@@ -152,7 +151,7 @@ const testSuite = (sessionPluginName: string) => {
             preValidation: fastifyPassport.authenticate('test', {
               successRedirect: '/',
               authInfo: false
-            }) as preValidationHookHandler
+            })
           },
           async () => ''
         )

--- a/test/independent-strategy-instances.test.ts
+++ b/test/independent-strategy-instances.test.ts
@@ -3,7 +3,6 @@ import { describe, test } from 'node:test'
 import { Strategy } from '../src/strategies'
 import { TestThirdPartyStrategy } from './authorize.test'
 import { getConfiguredTestServer, getRegisteredTestServer, TestStrategy } from './helpers'
-import { preValidationHookHandler } from 'fastify'
 
 class WelcomeStrategy extends Strategy {
   authenticate (request: any, _options?: { pauseStream?: boolean }) {
@@ -26,7 +25,7 @@ const testSuite = (sessionPluginName: string) => {
         {
           preValidation: fastifyPassport.authenticate(new WelcomeStrategy('welcome'), {
             authInfo: false
-          }) as preValidationHookHandler
+          })
         },
         async (request) => request.session.get('messages')
       )
@@ -37,7 +36,7 @@ const testSuite = (sessionPluginName: string) => {
             successRedirect: '/',
             successMessage: true,
             authInfo: false
-          }) as preValidationHookHandler
+          })
         },
         () => {}
       )
@@ -69,7 +68,7 @@ const testSuite = (sessionPluginName: string) => {
         {
           preValidation: fastifyPassport.authenticate([new WelcomeStrategy('welcome'), new TestStrategy('test')], {
             authInfo: false
-          }) as preValidationHookHandler
+          })
         },
         async (request) => `messages: ${request.session.get('messages')}`
       )
@@ -80,7 +79,7 @@ const testSuite = (sessionPluginName: string) => {
             successRedirect: '/',
             successMessage: true,
             authInfo: false
-          }) as preValidationHookHandler
+          })
         },
         () => {}
       )
@@ -112,7 +111,7 @@ const testSuite = (sessionPluginName: string) => {
         {
           preValidation: fastifyPassport.authenticate([new WelcomeStrategy('welcome'), 'test'], {
             authInfo: false
-          }) as preValidationHookHandler
+          })
         },
         async (request) => `messages: ${request.session.get('messages')}`
       )
@@ -123,7 +122,7 @@ const testSuite = (sessionPluginName: string) => {
             successRedirect: '/',
             successMessage: true,
             authInfo: false
-          }) as preValidationHookHandler
+          })
         },
         () => {}
       )
@@ -156,7 +155,7 @@ const testSuite = (sessionPluginName: string) => {
         {
           preValidation: fastifyPassport.authorize(
             new TestThirdPartyStrategy('third-party')
-          ) as preValidationHookHandler
+          )
         },
         async (request) => {
           const user = request.user as any

--- a/test/multi-instance.test.ts
+++ b/test/multi-instance.test.ts
@@ -1,4 +1,4 @@
-import { FastifyInstance, preValidationHookHandler } from 'fastify'
+import { FastifyInstance } from 'fastify'
 import assert from 'node:assert'
 import { beforeEach, describe, test } from 'node:test'
 import { Authenticator } from '../src/Authenticator'
@@ -60,14 +60,14 @@ async function TestStrategyModule (
     {
       preValidation: authenticator.authenticate(strategyName, {
         authInfo: false
-      }) as preValidationHookHandler
+      })
     },
     async () => `hello ${namespace}!`
   )
 
   instance.get(
     `/user/${namespace}`,
-    { preValidation: authenticator.authenticate(strategyName, { authInfo: false }) as preValidationHookHandler },
+    { preValidation: authenticator.authenticate(strategyName, { authInfo: false }) },
     async (request: any) => JSON.stringify(request[`user${namespace}`])
   )
 
@@ -77,7 +77,7 @@ async function TestStrategyModule (
       preValidation: authenticator.authenticate(strategyName, {
         successRedirect: `/${namespace}`,
         authInfo: false
-      }) as preValidationHookHandler
+      })
     },
     () => {}
   )
@@ -87,7 +87,7 @@ async function TestStrategyModule (
     {
       preValidation: authenticator.authenticate(strategyName, {
         authInfo: false
-      }) as preValidationHookHandler
+      })
     },
     async (request, reply) => {
       await request.logout()

--- a/test/multi-strategy-callback.test.ts
+++ b/test/multi-strategy-callback.test.ts
@@ -2,7 +2,6 @@ import { test, describe } from 'node:test'
 import assert from 'node:assert'
 import { getRegisteredTestServer } from './helpers'
 import { Strategy } from '../src/strategies'
-import { preValidationHookHandler } from 'fastify'
 
 // Strategy that always fails with a specific status
 class FailingStrategy extends Strategy {
@@ -39,7 +38,7 @@ const testSuite = (sessionPluginName: string) => {
               receivedStatuses = undefined // Should not be called with array for single strategy
               reply.code(401).send('Authentication failed')
             }
-          ) as preValidationHookHandler
+          )
         },
         async () => 'should not reach here'
       )
@@ -71,7 +70,7 @@ const testSuite = (sessionPluginName: string) => {
               receivedStatuses = statuses
               reply.code(401).send('Authentication failed')
             }
-          ) as preValidationHookHandler
+          )
         },
         async () => 'should not reach here'
       )
@@ -108,7 +107,7 @@ const testSuite = (sessionPluginName: string) => {
               receivedStatuses = statuses
               reply.code(401).send('Authentication failed')
             }
-          ) as preValidationHookHandler
+          )
         },
         async () => 'should not reach here'
       )
@@ -143,7 +142,7 @@ const testSuite = (sessionPluginName: string) => {
               // Success callback should not have status/statuses parameter
               reply.send('Authentication succeeded')
             }
-          ) as preValidationHookHandler
+          )
         },
         async () => 'should not reach here'
       )

--- a/test/passport.test.ts
+++ b/test/passport.test.ts
@@ -4,7 +4,6 @@ import { AuthenticateOptions } from '../src/AuthenticationRoute'
 import Authenticator from '../src/Authenticator'
 import { Strategy } from '../src/strategies'
 import { getConfiguredTestServer, getRegisteredTestServer, getTestServer, TestStrategy } from './helpers'
-import { preValidationHookHandler } from 'fastify'
 
 const testSuite = (sessionPluginName: string) => {
   describe(`${sessionPluginName} tests`, () => {
@@ -16,7 +15,7 @@ const testSuite = (sessionPluginName: string) => {
         {
           preValidation: fastifyPassport.authenticate('test', {
             authInfo: false
-          }) as preValidationHookHandler
+          })
         },
         async () => 'hello world!'
       )
@@ -25,7 +24,7 @@ const testSuite = (sessionPluginName: string) => {
         {
           preValidation: fastifyPassport.authenticate('test', {
             authInfo: false
-          }) as preValidationHookHandler
+          })
         },
         () => {}
       )
@@ -45,7 +44,7 @@ const testSuite = (sessionPluginName: string) => {
         {
           preValidation: fastifyPassport.authenticate('test', {
             authInfo: false
-          }) as preValidationHookHandler
+          })
         },
         async (request, reply) => {
           reply.send(request.session.get('messages'))
@@ -58,7 +57,7 @@ const testSuite = (sessionPluginName: string) => {
             successRedirect: '/',
             successMessage: 'welcome',
             authInfo: false
-          }) as preValidationHookHandler
+          })
         },
         () => {}
       )
@@ -105,7 +104,7 @@ const testSuite = (sessionPluginName: string) => {
         {
           preValidation: fastifyPassport.authenticate('test', {
             authInfo: false
-          }) as preValidationHookHandler
+          })
         },
         async (request) => request.session.get('messages')
       )
@@ -116,7 +115,7 @@ const testSuite = (sessionPluginName: string) => {
             successRedirect: '/',
             successMessage: true,
             authInfo: false
-          }) as preValidationHookHandler
+          })
         },
         () => {}
       )
@@ -152,7 +151,7 @@ const testSuite = (sessionPluginName: string) => {
           preValidation: fastifyPassport.authenticate('test', {
             failureMessage: 'first failure',
             authInfo: false
-          }) as preValidationHookHandler
+          })
         },
         () => {}
       )
@@ -162,7 +161,7 @@ const testSuite = (sessionPluginName: string) => {
           preValidation: fastifyPassport.authenticate('test', {
             failureMessage: 'second failure',
             authInfo: false
-          }) as preValidationHookHandler
+          })
         },
         () => {}
       )
@@ -217,7 +216,7 @@ const testSuite = (sessionPluginName: string) => {
         {
           preValidation: fastifyPassport.authenticate('test', {
             authInfo: false
-          }) as preValidationHookHandler
+          })
         },
         async (request) => request.session.get('messages')
       )
@@ -228,7 +227,7 @@ const testSuite = (sessionPluginName: string) => {
             successRedirect: '/',
             successMessage: 'welcome',
             authInfo: false
-          }) as preValidationHookHandler
+          })
         },
         () => {}
       )
@@ -257,7 +256,7 @@ const testSuite = (sessionPluginName: string) => {
         {
           preValidation: fastifyPassport.authenticate('test', {
             authInfo: false
-          }) as preValidationHookHandler
+          })
         },
         async (_request, reply) => reply.flash('success')
       )
@@ -268,7 +267,7 @@ const testSuite = (sessionPluginName: string) => {
             successRedirect: '/',
             successFlash: 'welcome',
             authInfo: false
-          }) as preValidationHookHandler
+          })
         },
         () => {}
       )
@@ -300,7 +299,7 @@ const testSuite = (sessionPluginName: string) => {
         {
           preValidation: fastifyPassport.authenticate('test', {
             authInfo: false
-          }) as preValidationHookHandler
+          })
         },
         async (_request, reply) => reply.flash('success')
       )
@@ -311,7 +310,7 @@ const testSuite = (sessionPluginName: string) => {
             successRedirect: '/',
             successFlash: true,
             authInfo: false
-          }) as preValidationHookHandler
+          })
         },
         () => {}
       )
@@ -343,7 +342,7 @@ const testSuite = (sessionPluginName: string) => {
         {
           preValidation: fastifyPassport.authenticate('test', {
             authInfo: false
-          }) as preValidationHookHandler
+          })
         },
         async () => 'hello world!'
       )
@@ -353,7 +352,7 @@ const testSuite = (sessionPluginName: string) => {
           preValidation: fastifyPassport.authenticate('test', {
             successRedirect: '/',
             authInfo: false
-          }) as preValidationHookHandler
+          })
         },
         () => {}
       )
@@ -387,7 +386,7 @@ const testSuite = (sessionPluginName: string) => {
             successRedirect: '/',
             assignProperty: 'user',
             authInfo: false
-          }) as preValidationHookHandler
+          })
         },
         (request: any, reply: any) => {
           reply.send(request.user)
@@ -414,7 +413,7 @@ const testSuite = (sessionPluginName: string) => {
         {
           preValidation: fastifyPassport.authenticate('test', {
             authInfo: false
-          }) as preValidationHookHandler
+          })
         },
         async () => 'hello world!'
       )
@@ -424,7 +423,7 @@ const testSuite = (sessionPluginName: string) => {
           preValidation: fastifyPassport.authenticate('test', {
             successReturnToOrRedirect: '/',
             authInfo: false
-          }) as preValidationHookHandler
+          })
         },
         () => {}
       )
@@ -454,7 +453,7 @@ const testSuite = (sessionPluginName: string) => {
       server.get(
         '/',
         {
-          preValidation: fastifyPassport.authenticate('test', { authInfo: true }) as preValidationHookHandler
+          preValidation: fastifyPassport.authenticate('test', { authInfo: true })
         },
         async () => 'hello world!'
       )
@@ -464,7 +463,7 @@ const testSuite = (sessionPluginName: string) => {
           preValidation: fastifyPassport.authenticate('test', {
             successRedirect: '/',
             authInfo: true
-          }) as preValidationHookHandler
+          })
         },
         () => {}
       )
@@ -495,7 +494,7 @@ const testSuite = (sessionPluginName: string) => {
       server.get(
         '/',
         {
-          preValidation: fastifyPassport.authenticate('test', { authInfo: true }) as preValidationHookHandler
+          preValidation: fastifyPassport.authenticate('test', { authInfo: true })
         },
         async () => 'hello world!'
       )
@@ -505,7 +504,7 @@ const testSuite = (sessionPluginName: string) => {
           preValidation: fastifyPassport.authenticate('test', {
             successRedirect: '/',
             authInfo: true
-          }) as preValidationHookHandler
+          })
         },
         () => {}
       )
@@ -542,7 +541,7 @@ const testSuite = (sessionPluginName: string) => {
           preValidation: fastifyPassport.authenticate('test', {
             failureRedirect: '/failure',
             authInfo: false
-          }) as preValidationHookHandler
+          })
         },
         () => {}
       )
@@ -565,7 +564,7 @@ const testSuite = (sessionPluginName: string) => {
           preValidation: fastifyPassport.authenticate('test', {
             failureMessage: 'try again',
             authInfo: false
-          }) as preValidationHookHandler
+          })
         },
         async () => 'login page'
       )
@@ -601,7 +600,7 @@ const testSuite = (sessionPluginName: string) => {
           preValidation: fastifyPassport.authenticate('test', {
             failureFlash: 'try again',
             authInfo: false
-          }) as preValidationHookHandler
+          })
         },
         () => {}
       )
@@ -634,7 +633,7 @@ const testSuite = (sessionPluginName: string) => {
           preValidation: fastifyPassport.authenticate('test', {
             failureFlash: true,
             authInfo: false
-          }) as preValidationHookHandler
+          })
         },
         () => {}
       )
@@ -663,7 +662,7 @@ const testSuite = (sessionPluginName: string) => {
         {
           preValidation: fastifyPassport.authenticate('test', {
             authInfo: false
-          }) as preValidationHookHandler
+          })
         },
         async () => 'hello world!'
       )
@@ -679,7 +678,7 @@ const testSuite = (sessionPluginName: string) => {
       server.get(
         '/',
         {
-          preValidation: fastifyPassport.authenticate('test', { authInfo: true }) as preValidationHookHandler
+          preValidation: fastifyPassport.authenticate('test', { authInfo: true })
         },
         async () => 'hello world!'
       )
@@ -710,7 +709,7 @@ const testSuite = (sessionPluginName: string) => {
       server.get(
         '/',
         {
-          preValidation: fastifyPassport.authenticate('test', { authInfo: true }) as preValidationHookHandler
+          preValidation: fastifyPassport.authenticate('test', { authInfo: true })
         },
         async () => 'hello world!'
       )
@@ -751,7 +750,7 @@ const testSuite = (sessionPluginName: string) => {
         {
           preValidation: fastifyPassport.authenticate('test', {
             authInfo: false
-          }) as preValidationHookHandler
+          })
         },
         async (request, reply) => {
           reply.send(request.session.get('messages'))
@@ -765,7 +764,7 @@ const testSuite = (sessionPluginName: string) => {
             successRedirect: '/',
             successMessage: 'welcome',
             authInfo: false
-          }) as preValidationHookHandler
+          })
         },
         () => {}
       )

--- a/test/session-isolation.test.ts
+++ b/test/session-isolation.test.ts
@@ -1,24 +1,23 @@
 import { test, describe, beforeEach } from 'node:test'
 import assert from 'node:assert'
 import { generateTestUser, getConfiguredTestServer, TestBrowserSession } from './helpers'
-import { preValidationHookHandler } from 'fastify'
 
 function createServer () {
   const { server, fastifyPassport } = getConfiguredTestServer()
 
   server.get(
     '/protected',
-    { preValidation: fastifyPassport.authenticate('test', { authInfo: false }) as preValidationHookHandler },
+    { preValidation: fastifyPassport.authenticate('test', { authInfo: false }) },
     async () => 'hello!'
   )
   server.get(
     '/my-id',
-    { preValidation: fastifyPassport.authenticate('test', { authInfo: false }) as preValidationHookHandler },
+    { preValidation: fastifyPassport.authenticate('test', { authInfo: false }) },
     async (request) => String((request.user as any).id)
   )
   server.post(
     '/login',
-    { preValidation: fastifyPassport.authenticate('test', { authInfo: false }) as preValidationHookHandler },
+    { preValidation: fastifyPassport.authenticate('test', { authInfo: false }) },
     async () => 'success'
   )
 
@@ -29,7 +28,7 @@ function createServer () {
 
   server.post(
     '/logout',
-    { preValidation: fastifyPassport.authenticate('test', { authInfo: false }) as preValidationHookHandler },
+    { preValidation: fastifyPassport.authenticate('test', { authInfo: false }) },
     async (request, reply) => {
       await request.logout()
       reply.send('logged out')

--- a/test/session-serialization.test.ts
+++ b/test/session-serialization.test.ts
@@ -1,6 +1,6 @@
 import { test, describe, mock } from 'node:test'
 import assert from 'node:assert'
-import { FastifyInstance, preValidationHookHandler } from 'fastify'
+import { FastifyInstance } from 'fastify'
 import { FastifyRequest } from 'fastify/types/request'
 import Authenticator from '../src/Authenticator'
 import { getTestServer, TestDatabaseStrategy, TestStrategy } from './helpers'
@@ -31,7 +31,7 @@ const testSuite = (sessionPluginName: string) => {
           {
             preValidation: fastifyPassport.authenticate('test', {
               authInfo: false
-            }) as preValidationHookHandler
+            })
           },
           async () => 'hello world!'
         )
@@ -41,7 +41,7 @@ const testSuite = (sessionPluginName: string) => {
             preValidation: fastifyPassport.authenticate('test', {
               successRedirect: '/',
               authInfo: false
-            }) as preValidationHookHandler
+            })
           },
           () => {}
         )

--- a/test/strategies-integration.test.ts
+++ b/test/strategies-integration.test.ts
@@ -6,7 +6,6 @@ import { OAuth2Strategy as GoogleStrategy } from 'passport-google-oauth'
 import { Configuration as OpenIdClientConfiguration } from 'openid-client'
 import { Strategy as OpenIdClientStrategy } from 'openid-client/passport'
 import { getConfiguredTestServer, TestStrategy } from './helpers'
-import { preValidationHookHandler } from 'fastify'
 
 const testSuite = (sessionPluginName: string) => {
   describe(`${sessionPluginName} tests`, () => {
@@ -27,7 +26,7 @@ const testSuite = (sessionPluginName: string) => {
         {
           preValidation: fastifyPassport.authenticate('google', {
             authInfo: false
-          }) as preValidationHookHandler
+          })
         },
         async () => 'hello world!'
       )
@@ -36,7 +35,7 @@ const testSuite = (sessionPluginName: string) => {
         {
           preValidation: fastifyPassport.authenticate('google', {
             authInfo: false
-          }) as preValidationHookHandler
+          })
         },
         async () => 'hello'
       )
@@ -62,7 +61,7 @@ const testSuite = (sessionPluginName: string) => {
         {
           preValidation: fastifyPassport.authenticate('facebook', {
             authInfo: false
-          }) as preValidationHookHandler
+          })
         },
         async () => 'hello world!'
       )
@@ -71,7 +70,7 @@ const testSuite = (sessionPluginName: string) => {
         {
           preValidation: fastifyPassport.authenticate('facebook', {
             authInfo: false
-          }) as preValidationHookHandler
+          })
         },
         async () => 'hello'
       )
@@ -97,7 +96,7 @@ const testSuite = (sessionPluginName: string) => {
         {
           preValidation: fastifyPassport.authenticate('github', {
             authInfo: false
-          }) as preValidationHookHandler
+          })
         },
         async () => 'hello world!'
       )
@@ -106,7 +105,7 @@ const testSuite = (sessionPluginName: string) => {
         {
           preValidation: fastifyPassport.authenticate('github', {
             authInfo: false
-          }) as preValidationHookHandler
+          })
         },
         async () => 'hello'
       )
@@ -136,7 +135,7 @@ const testSuite = (sessionPluginName: string) => {
         {
           preValidation: fastifyPassport.authenticate('openid-client', {
             authInfo: false
-          }) as preValidationHookHandler
+          })
         },
         async () => 'hello world!'
       )
@@ -145,7 +144,7 @@ const testSuite = (sessionPluginName: string) => {
         {
           preValidation: fastifyPassport.authenticate('openid-client', {
             authInfo: false
-          }) as preValidationHookHandler
+          })
         },
         async () => 'hello'
       )

--- a/test/strategy.test.ts
+++ b/test/strategy.test.ts
@@ -3,7 +3,6 @@ import { describe, test } from 'node:test'
 import Authenticator from '../src/Authenticator'
 import { Strategy } from '../src/strategies'
 import { getConfiguredTestServer, TestStrategy } from './helpers'
-import type { preValidationHookHandler } from 'fastify'
 
 const testSuite = (sessionPluginName: string) => {
   describe(`${sessionPluginName} tests`, () => {
@@ -31,7 +30,7 @@ const testSuite = (sessionPluginName: string) => {
       const { server, fastifyPassport } = getConfiguredTestServer('test', new ErrorStrategy('test'))
       server.get(
         '/',
-        { preValidation: fastifyPassport.authenticate('test') as preValidationHookHandler },
+        { preValidation: fastifyPassport.authenticate('test') },
         async () => 'hello world!'
       )
 
@@ -51,7 +50,7 @@ const testSuite = (sessionPluginName: string) => {
       const { server, fastifyPassport } = getConfiguredTestServer('test', new ErrorStrategy('test'))
       server.get(
         '/',
-        { preValidation: fastifyPassport.authenticate('test') as preValidationHookHandler },
+        { preValidation: fastifyPassport.authenticate('test') },
         async () => 'hello world!'
       )
 
@@ -74,7 +73,7 @@ const testSuite = (sessionPluginName: string) => {
         {
           preValidation: fastifyPassport.authenticate('test', {
             failureFlash: true
-          }) as preValidationHookHandler
+          })
         },
         async () => 'hello world!'
       )
@@ -94,7 +93,7 @@ const testSuite = (sessionPluginName: string) => {
       const { server, fastifyPassport } = getConfiguredTestServer('test', new ErrorStrategy('test'))
       server.get(
         '/',
-        { preValidation: fastifyPassport.authenticate('test') as preValidationHookHandler },
+        { preValidation: fastifyPassport.authenticate('test') },
         async () => 'hello world!'
       )
 


### PR DESCRIPTION
## Summary

- expose `authenticate()` and `authorize()` as Fastify async pre-validation hooks
- remove the type assertions that masked incompatibility with Fastify 5.8 route shorthand options
- add regression coverage for direct hook registration with a typed query string
- preserve direct route-handler compatibility

## Why

Fastify 5.8 changed route shorthand hook return typing to `void | Promise<unknown>`. The existing `RouteHandlerMethod` return annotation resolves to `unknown`, making passport authentication handlers incompatible with `preValidation` even though the implementation is async.

## Validation

- `npm test` — 177 tests, 174 passed, 3 skipped
- `npm run lint`
- `npm run build`
- `git diff --check`

Fixes fastify/fastify#6576