### PR TITLE
fix: accept falsy serialized user ids

### DIFF
--- a/src/Authenticator.ts
+++ b/src/Authenticator.ts
@@ -6,6 +6,7 @@ import { SecureSessionManager } from './session-managers/SecureSessionManager'
 import type { AnyStrategy } from './strategies/index'
 import type { Strategy } from './strategies/base'
 import { SessionStrategy } from './strategies/SessionStrategy'
+import { isStorableSessionValue, kNoResult, type NoResult } from './session-value'
 
 export type SerializeFunction<User = any, SerializedUser = any> = (
   user: User,
@@ -269,7 +270,8 @@ export class Authenticator {
   async serializeUser<User, StoredUser = any>(user: User, request: FastifyRequest): Promise<StoredUser> {
     const result = await this.runStack(this.serializers, user, request)
 
-    if (result) {
+    // Falsy ids like `0`, `''` and `false` are valid, so only a missing result is a failure.
+    if (result !== kNoResult && isStorableSessionValue(result)) {
       return result
     } else {
       throw new Error(`Failed to serialize user into session. Tried ${this.serializers.length} serializers.`)
@@ -294,10 +296,12 @@ export class Authenticator {
   async deserializeUser<StoredUser>(stored: StoredUser, request: FastifyRequest): Promise<StoredUser | false> {
     const result = await this.runStack(this.deserializers, stored, request)
 
-    if (result) {
-      return result
-    } else if (result === null || result === false) {
+    // `null` and `false` are the documented way for a deserializer to report that the session
+    // no longer maps to a user, which logs the session out rather than erroring.
+    if (result === null || result === false) {
       return false
+    } else if (result !== kNoResult && result !== undefined) {
+      return result
     } else {
       throw new Error(`Failed to deserialize user out of session. Tried ${this.deserializers.length} serializers.`)
     }
@@ -332,7 +336,7 @@ export class Authenticator {
   async transformAuthInfo (info: any, request: FastifyRequest) {
     const result = await this.runStack(this.infoTransformers, info, request)
     // if no transformers are registered (or they all pass), the default behavior is to use the un-transformed info as-is
-    return result || info
+    return result === kNoResult || result === undefined ? info : result
   }
 
   /**
@@ -346,7 +350,16 @@ export class Authenticator {
     return this.strategies[name]
   }
 
-  private async runStack<Result, A, B>(stack: ((...args: [A, B]) => Promise<Result>)[], ...args: [A, B]) {
+  /**
+   * Runs each function in `stack` until one of them returns, and returns that result. Functions
+   * opt out of handling the arguments by throwing `'pass'`. Returns the `kNoResult` sentinel if
+   * the stack is exhausted without any function returning, which callers must distinguish from a
+   * function returning a falsy-but-meaningful value like `0`, `''` or `false`.
+   */
+  private async runStack<Result, A, B>(
+    stack: ((...args: [A, B]) => Promise<Result>)[],
+    ...args: [A, B]
+  ): Promise<Result | NoResult> {
     for (const attempt of stack) {
       try {
         return await attempt(...args)
@@ -358,6 +371,7 @@ export class Authenticator {
         }
       }
     }
+    return kNoResult
   }
 }
 

--- a/src/session-managers/SecureSessionManager.ts
+++ b/src/session-managers/SecureSessionManager.ts
@@ -3,6 +3,7 @@ import type { AuthenticateOptions } from '../AuthenticationRoute'
 import type { SerializeFunction } from '../Authenticator'
 import type { FastifySessionObject } from '@fastify/session'
 import type { Session, SessionData } from '@fastify/secure-session'
+import { isStorableSessionValue } from '../session-value'
 
 type Request = FastifyRequest & { session: FastifySessionObject | Session<SessionData> }
 
@@ -55,7 +56,7 @@ export class SecureSessionManager {
 
     // Handle @fastify/session to prevent token/CSRF fixation
     if (request.session.regenerate) {
-      if (this.clearSessionOnLogin && (object || object === 0)) {
+      if (this.clearSessionOnLogin && isStorableSessionValue(object)) {
         const keepSessionInfoKeys: string[] = [...this.clearSessionIgnoreFields]
         if (options?.keepSessionInfo) {
           keepSessionInfoKeys.push(...Object.keys(request.session))
@@ -72,7 +73,7 @@ export class SecureSessionManager {
       // Handle @fastify/secure-session against CSRF fixation
       // TODO: This is quite hacky. The best option would be having a regenerate method
       // on secure-session as well
-    } else if (this.clearSessionOnLogin && (object || object === 0)) {
+    } else if (this.clearSessionOnLogin && isStorableSessionValue(object)) {
       const currentData: SessionData = request.session?.data() ?? {}
       for (const field of Object.keys(currentData)) {
         if (options?.keepSessionInfo || this.clearSessionIgnoreFields.includes(field)) {

--- a/src/session-value.ts
+++ b/src/session-value.ts
@@ -1,0 +1,22 @@
+/**
+ * Sentinel returned by `Authenticator#runStack` when no function in the stack produced a
+ * result, either because the stack was empty or because every entry passed by throwing
+ * `'pass'`. It exists so that "nothing handled this" can be told apart from "something
+ * handled this and legitimately returned a falsy value" such as `0`, `''` or `false`.
+ */
+export const kNoResult = Symbol('fastify-passport.noResult')
+
+export type NoResult = typeof kNoResult
+
+/**
+ * Whether a serialized user is something we can actually store in, and read back out of, a
+ * session. Anything other than `undefined` and `null` qualifies, including falsy values like
+ * `0`, `''` and `false`, which are all valid user ids.
+ *
+ * `undefined` and `null` do not qualify because a session that holds them is indistinguishable
+ * from a session that holds no user at all, so accepting them would silently log the user out
+ * on the next request.
+ */
+export function isStorableSessionValue (value: unknown): boolean {
+  return value !== undefined && value !== null
+}

--- a/src/strategies/SessionStrategy.ts
+++ b/src/strategies/SessionStrategy.ts
@@ -1,6 +1,7 @@
 import { Strategy } from './base'
 import type { DeserializeFunction } from '../Authenticator'
 import type { FastifyRequest } from 'fastify'
+import { isStorableSessionValue } from '../session-value'
 
 /**
  * Default strategy that authenticates already-authenticated requests by retrieving their auth information from the Fastify session.
@@ -44,7 +45,7 @@ export class SessionStrategy extends Strategy {
 
     const sessionUser = request.passport.sessionManager.getUserFromSession(request)
 
-    if (sessionUser || sessionUser === 0) {
+    if (isStorableSessionValue(sessionUser)) {
       this.deserializeUser(sessionUser, request)
         .catch((err: Error) => this.error(err))
         .then(async (user?: any) => {

--- a/test/falsy-serialized-user.test.ts
+++ b/test/falsy-serialized-user.test.ts
@@ -1,0 +1,181 @@
+import { test, describe } from 'node:test'
+import assert from 'node:assert'
+import { FastifyInstance } from 'fastify'
+import { FastifyRequest } from 'fastify/types/request'
+import Authenticator from '../src/Authenticator'
+import { getTestServer, TestStrategy } from './helpers'
+
+const emptyRequest = {} as unknown as FastifyRequest
+
+/** Ids that are falsy but are still perfectly valid things to store in a session. */
+const falsyIds = [0, '', false]
+
+describe('Authenticator#serializeUser with falsy serialized ids', () => {
+  for (const id of falsyIds) {
+    test(`returns ${JSON.stringify(id)} rather than throwing`, async () => {
+      const fastifyPassport = new Authenticator()
+      fastifyPassport.registerUserSerializer(async () => id)
+
+      assert.strictEqual(await fastifyPassport.serializeUser({ id }, emptyRequest), id)
+    })
+  }
+
+  test('still throws when no serializer is registered', async () => {
+    const fastifyPassport = new Authenticator()
+
+    await assert.rejects(
+      fastifyPassport.serializeUser({ id: 1 }, emptyRequest),
+      /Failed to serialize user into session. Tried 0 serializers./
+    )
+  })
+
+  test('still throws when every serializer passes', async () => {
+    const fastifyPassport = new Authenticator()
+    fastifyPassport.registerUserSerializer(async () => {
+      throw 'pass' // eslint-disable-line no-throw-literal
+    })
+
+    await assert.rejects(
+      fastifyPassport.serializeUser({ id: 1 }, emptyRequest),
+      /Failed to serialize user into session. Tried 1 serializers./
+    )
+  })
+
+  for (const id of [undefined, null]) {
+    test(`still throws when a serializer returns ${String(id)}`, async () => {
+      const fastifyPassport = new Authenticator()
+      fastifyPassport.registerUserSerializer(async () => id)
+
+      await assert.rejects(
+        fastifyPassport.serializeUser({ id }, emptyRequest),
+        /Failed to serialize user into session. Tried 1 serializers./
+      )
+    })
+  }
+})
+
+describe('Authenticator#deserializeUser with falsy serialized ids', () => {
+  for (const id of falsyIds) {
+    test(`hands ${JSON.stringify(id)} to the registered deserializers`, async () => {
+      const fastifyPassport = new Authenticator()
+      const seen: unknown[] = []
+      fastifyPassport.registerUserDeserializer(async (stored) => {
+        seen.push(stored)
+        return { name: 'test' }
+      })
+
+      assert.deepStrictEqual(await fastifyPassport.deserializeUser(id, emptyRequest), { name: 'test' })
+      assert.deepStrictEqual(seen, [id])
+    })
+  }
+})
+
+const sessionPlugins = ['@fastify/session', '@fastify/secure-session'] as const
+
+const setupServer = async (fastifyPassport: Authenticator) => {
+  const server = getTestServer()
+  server.register(fastifyPassport.initialize())
+  server.register(fastifyPassport.secureSession())
+  server.post(
+    '/prime',
+    async (request) => {
+      request.session.set('preLogin', 'planted')
+      return 'primed'
+    }
+  )
+  server.post(
+    '/login',
+    { preValidation: fastifyPassport.authenticate('test', { authInfo: false }) },
+    async () => 'logged in'
+  )
+  server.get(
+    '/protected',
+    { preValidation: fastifyPassport.authenticate('test', { authInfo: false }) },
+    async (request) => JSON.stringify(request.user)
+  )
+  server.get('/session', async (request) => String(request.session.get('preLogin')))
+  return server
+}
+
+const login = (server: FastifyInstance, cookie?: string) =>
+  server.inject({
+    method: 'POST',
+    url: '/login',
+    payload: { login: 'test', password: 'test' },
+    headers: cookie ? { cookie } : {}
+  })
+
+for (const sessionPluginName of sessionPlugins) {
+  describe(`${sessionPluginName} tests`, () => {
+    describe('logging in a user whose serialized id is falsy', () => {
+      for (const id of falsyIds) {
+        test(`round trips a user serialized to ${JSON.stringify(id)}`, async () => {
+          process.env.SESSION_PLUGIN = sessionPluginName
+          try {
+            const fastifyPassport = new Authenticator()
+            fastifyPassport.use('test', new TestStrategy('test'))
+            const seen: unknown[] = []
+            fastifyPassport.registerUserSerializer(async () => id)
+            fastifyPassport.registerUserDeserializer(async (stored) => {
+              seen.push(stored)
+              return { name: 'test', id }
+            })
+
+            const server = await setupServer(fastifyPassport)
+
+            const loginResponse = await login(server)
+            assert.strictEqual(loginResponse.statusCode, 200)
+            assert.strictEqual(loginResponse.body, 'logged in')
+
+            const protectedResponse = await server.inject({
+              method: 'GET',
+              url: '/protected',
+              headers: { cookie: loginResponse.headers['set-cookie'] as string }
+            })
+
+            assert.strictEqual(protectedResponse.statusCode, 200)
+            assert.deepStrictEqual(JSON.parse(protectedResponse.body), { name: 'test', id })
+            // the id must survive the session round trip untouched, not be coerced
+            assert.deepStrictEqual(seen, [id])
+          } finally {
+            delete process.env.SESSION_PLUGIN
+          }
+        })
+
+        test(`clears the pre-login session when the serialized id is ${JSON.stringify(id)}`, async () => {
+          process.env.SESSION_PLUGIN = sessionPluginName
+          try {
+            const fastifyPassport = new Authenticator()
+            fastifyPassport.use('test', new TestStrategy('test'))
+            fastifyPassport.registerUserSerializer(async () => id)
+            fastifyPassport.registerUserDeserializer(async () => ({ name: 'test', id }))
+
+            const server = await setupServer(fastifyPassport)
+
+            const primeResponse = await server.inject({ method: 'POST', url: '/prime' })
+            const primedCookie = primeResponse.headers['set-cookie'] as string
+
+            const sessionBeforeLogin = await server.inject({
+              method: 'GET',
+              url: '/session',
+              headers: { cookie: primedCookie }
+            })
+            assert.strictEqual(sessionBeforeLogin.body, 'planted')
+
+            const loginResponse = await login(server, primedCookie)
+            assert.strictEqual(loginResponse.statusCode, 200)
+
+            const sessionAfterLogin = await server.inject({
+              method: 'GET',
+              url: '/session',
+              headers: { cookie: (loginResponse.headers['set-cookie'] ?? primedCookie) as string }
+            })
+            assert.strictEqual(sessionAfterLogin.body, 'undefined')
+          } finally {
+            delete process.env.SESSION_PLUGIN
+          }
+        })
+      }
+    })
+  })
+}


### PR DESCRIPTION
## Problem

`Authenticator#serializeUser` checked the serializer stack's result for truthiness:

```ts
const result = await this.runStack(this.serializers, user, request)
if (result) {
  return result
} else {
  throw new Error(`Failed to serialize user into session. ...`)
}
```

But a serializer opts out of handling a user by throwing `'pass'`, not by returning a falsy value. So a serializer returning `0`, `''` or `false` — all valid user ids — was read as "no serializer handled this user", and **every login attempt for that user failed with an HTTP 500**. This is the pattern straight out of the README (`registerUserSerializer(async (user) => user.id)`), so any app with a user whose id is `0` had that user permanently locked out.

Reproduced end to end through the HTTP login flow against both `@fastify/secure-session` and `@fastify/session`.

To be clear about severity: this fails closed. A login is denied, never granted — no bypass, no escalation, and it isn't attacker-triggerable, since whether a user serializes to a falsy value is a property of the application's own serializer. It's a correctness bug, not a security issue.

## Fix

`runStack` couldn't express the difference between "the stack was exhausted" and "a function returned a falsy value" — both surfaced as `undefined`. It now returns a `kNoResult` sentinel when exhausted, so callers can tell the two apart.

`serializeUser` then accepts any result except `undefined`/`null`. Those two stay rejected on purpose: a session holding either is indistinguishable from a session holding no user at all, so accepting them would silently log the user out on the next request rather than erroring loudly.

### The part that makes this more than a one-line change

`SecureSessionManager#logIn` and `SessionStrategy#authenticate` already special-cased `0`, but not `''` or `false`. Loosening `serializeUser` on its own would let those two values through into a state that's worse than the crash — I tested it:

| serialized id | login | pre-login session data | `request.user` after login |
| --- | --- | --- | --- |
| `0` | 200 | cleared | restored |
| `''` | 200 | **survives** | **null** |
| `false` | 200 | **survives** | **null** |
| `'normal'` | 200 | cleared | restored |

Login reports success, `clearSessionOnLogin` is quietly skipped so pre-login session data crosses the login boundary, and the session strategy never deserializes the user, leaving `request.user` unset on every subsequent request.

Both call sites now share one predicate (`isStorableSessionValue`) with `serializeUser`, so the set of values serialization accepts and the set the session layer treats as "logged in" can't drift apart again.

Two adjacent spots using the same loose pattern are fixed for consistency: `deserializeUser` (`null`/`false` remain the documented "session no longer maps to a user" signal; `undefined` still throws as before) and `transformAuthInfo`, whose `result || info` discarded a falsy transform result.

## Tests

New `test/falsy-serialized-user.test.ts`, written before the fix — 15 of its 22 assertions failed on `main`:

- `serializeUser` returns `0`, `''`, `false` instead of throwing
- it still throws with no serializers registered, when all serializers pass, and when one returns `undefined` or `null`
- full login round trip for each falsy id against **both** session plugins, asserting the id survives the session untouched (`0` stays a number, not `'0'`) and `request.user` is restored
- `clearSessionOnLogin` still clears pre-login session data when the id is falsy

Full suite: 199 tests passing, lint clean. Line coverage 98.78% → 98.82%, branch 96.68% → 97.55%.

## Credit

Reported privately; the reporter identified the root cause exactly. Happy to add a credit line here once they confirm how they'd like to be named.